### PR TITLE
gfx: fix compile errors and clippy warnings

### DIFF
--- a/docs/issues/Lightning_M1.md
+++ b/docs/issues/Lightning_M1.md
@@ -1,0 +1,87 @@
+Title: Lightning M1 — Foundations: G‑Buffer, Hi‑Z, Temporal, SSR/SSGI
+
+Goal
+- Establish the core rendering infrastructure for stable environment lighting: G‑Buffer pass, depth pyramid, temporal reprojection/history, and baseline screen‑space reflections (SSR) and screen‑space diffuse GI (SSGI). Wire all of this to our existing sun/sky/time‑of‑day system.
+
+Scope
+- Add new render passes and shared utilities without breaking current forward paths. Keep modules cohesive and documented per repo guidelines.
+
+Planned files and module map (aligned with src/README.md)
+- `src/gfx/gbuffer.rs` — Create and manage MRT targets; record G‑Buffer pass.
+- `src/gfx/gbuffer.wgsl` — VS/FS writing: normal (ws), albedo, roughness, metalness, emissive, motion vectors.
+- `src/gfx/hiz.rs` — Build hierarchical depth pyramid via compute; provide SRV views per mip.
+- `src/gfx/hiz.comp.wgsl` — Compute shader for min‑reduce/downsample from full‑res depth.
+- `src/gfx/temporal/mod.rs` — Module index and shared types.
+- `src/gfx/temporal/reprojection.rs` — Jitter, prev matrices, velocity usage, history clamp masks.
+- `src/gfx/temporal/history.rs` — History textures management + neighborhood clamp.
+- `src/gfx/reflections/ssr.rs` — Screen‑space reflections pass: ray march in Hi‑Z, refine, temporal accumulate.
+- `src/gfx/ssr.wgsl` — WGSL for SSR ray‑march + resolve.
+- `src/gfx/gi/ssgi.rs` — Screen‑space diffuse GI: cosine‑weighted rays, temporal accumulation, fallback to sky SH.
+- `src/gfx/ssgi.wgsl` — WGSL for SSGI.
+- `src/gfx/pipeline.rs` — Extend to create pipelines and bind group layouts for the above passes.
+- `src/gfx/mod.rs` — Integrate passes into init/resize/render; add a `LightingConfig` to control toggles.
+- Tests: co‑located `#[cfg(test)]` in `temporal/reprojection.rs` and `hiz.rs`.
+
+Connections to existing hierarchy (read src/README.md)
+- `src/gfx/sky.rs` already drives sun dir and SH. Ensure new passes consume `Globals` consistently.
+- Avoid bloating `shader.wgsl`; add dedicated WGSL files per pass and load them in `pipeline.rs`.
+- Update `src/README.md` sections under `gfx/` to document each new module’s responsibility.
+
+Acceptance criteria
+- G‑Buffer renders for terrain + wizards without visual regressions in the current scene.
+- Hi‑Z built each frame; SSR and SSGI use it for marching.
+- Temporal reprojection stable on camera motion: limited ghosting thanks to history clamp; emissive flicker handled by reactive mask.
+- SSR: visible reflections for on‑screen hits; falls back to sky when miss.
+- SSGI: subtle diffuse bounce; falls back cleanly to sky SH.
+- Unit tests: reprojection math (matrix/game units), and depth pyramid downsample invariants.
+
+Detailed tasks
+- G‑Buffer
+  - Implement `src/gfx/gbuffer.rs` with MRT creation (formats suggested below).
+  - Author `src/gfx/gbuffer.wgsl` VS/FS; output motion vectors using current vs previous clip positions.
+  - Modify terrain/wizard material paths to supply base PBR params for the G‑Buffer.
+  - Pipeline wiring: extend `src/gfx/pipeline.rs` to compile/link the G‑Buffer pass.
+
+- Hi‑Z
+  - Implement `src/gfx/hiz.rs` and `src/gfx/hiz.comp.wgsl` for mip downsample (min reduction for depth).
+  - Build after G‑Buffer; expose a helper to query appropriate mip for step size.
+
+- Temporal reprojection
+  - Add `src/gfx/temporal/reprojection.rs` and `history.rs` with docblocks and public helpers.
+  - Maintain previous view‑proj and jitter; produce clamp masks using neighborhood statistics.
+  - Provide a shared bind layout for history textures; update in `pipeline.rs`.
+
+- SSR
+  - Implement `src/gfx/reflections/ssr.rs` and `src/gfx/ssr.wgsl`.
+  - Use roughness‑aware step counts; binary search refine; temporal accumulate with history.
+  - Fallback to environment (sky) when miss.
+
+- SSGI
+  - Implement `src/gfx/gi/ssgi.rs` and `src/gfx/ssgi.wgsl`.
+  - Cosine‑weighted rays in screen space; temporal accumulation; fallback to sky SH when miss.
+
+- Integration and config
+  - Add a `LightingConfig` to `src/gfx/mod.rs` with toggles: enable_ssr, enable_ssgi, temporal_strength, max_ssr_steps, etc.
+  - Ensure all public types/functions have rustdoc; add brief module‑level docblocks.
+  - Update `src/README.md` to reflect new files and responsibilities.
+
+Suggested formats (tune per GPU tier)
+- Albedo+Emissive: `RGBA16F`
+- Normal (oct‑encoded): `RG16F`
+- Roughness: `R8`
+- Metalness: `R8`
+- Motion vectors: `RG16`
+- Depth: `D32Float` (SRV read for Hi‑Z build)
+
+Tests
+- `temporal/reprojection.rs`: verify reprojection of a static point is identity with zero jitter; verify sub‑pixel jitter sequences map to expected offsets.
+- `hiz.rs`: CPU reference for a small depth image to verify first two mip levels (min) match compute shader.
+
+Out of scope
+- Off‑screen ray hits (defer to Lightning M2/M3).
+- Multi‑bounce GI and denoisers (Lightning M4).
+
+Housekeeping
+- Follow dependency policy: if any new crate is needed, add via `cargo add`, not manual edits.
+- Keep the repo compiling; run `cargo fmt` and `cargo clippy -- -D warnings`.
+

--- a/docs/issues/Lightning_M2.md
+++ b/docs/issues/Lightning_M2.md
@@ -1,0 +1,74 @@
+Title: Lightning M2 — Indirect Capture Atlas (Tile‑based surface captures)
+
+Goal
+- Provide robust lighting data for rays that leave the screen by capturing material/lighting from representative viewpoints per mesh into a runtime atlas. Integrate with time‑of‑day so captures refresh progressively as sun/sky changes.
+
+Scope
+- Offline/at‑import descriptors for per‑mesh capture tiles; runtime atlas management; recapture scheduler; sampling path at ray hits; basic debug overlays.
+
+Planned files and module map (aligned with src/README.md)
+- Assets/import
+  - `src/assets/capture.rs` — Build/generate per‑mesh capture descriptors (tile directions, projection params, footprints) during import.
+  - Optional CLI: `src/bin/capture_gen.rs` — One‑time/offline generator to write sidecar JSON for meshes.
+
+- Renderer: capture system
+  - `src/gfx/gi/capture/atlas.rs` — Atlas allocation, residency, and views.
+  - `src/gfx/gi/capture/recapture.rs` — Budgeted recapture scheduler (distance/importance/age); TOD invalidation policies.
+  - `src/gfx/gi/capture/sampling.rs` — Project ray hits to capture tile domain; nearest‑tile selection and blending.
+  - `src/gfx/gi/capture/capture.wgsl` — Offscreen pass shader to render attributes or pre‑shaded radiance into the atlas.
+  - `src/gfx/pipeline.rs` — Extend with capture pipelines and bind layouts.
+  - `src/gfx/mod.rs` — Integrate capture updates into per‑frame render order.
+
+- Debug tools
+  - `src/gfx/debug/capture_viz.rs` — Visualize tile placement per mesh in scene.
+  - `src/gfx/debug/atlas_inspector.rs` — On‑screen viewer/heatmap for the atlas and residency.
+
+Connections to existing hierarchy (read src/README.md)
+- `src/gfx/sky.rs` is the single authority for sun/sky/TOD; expose change deltas for recapture invalidation.
+- `src/gfx/types.rs` may need small structs for capture metadata UBOs; document std140 padding if used.
+- Update `src/README.md` under `assets/` and `gfx/` to describe the new capture pipeline and tools.
+
+Acceptance criteria
+- Meshes produce capture descriptors (either at import or via the CLI) with small tile counts and reasonable coverage.
+- A runtime atlas updates a limited number of tiles per frame near the camera; residency and heatmaps are visible in overlays.
+- GI/SSR sampling can query the atlas when screen‑space rays miss, improving stability relative to Phase 1.
+- Captures gradually refresh as TOD changes (sun angle/turbidity deltas) without large hitches.
+
+Detailed tasks
+- Descriptor generation
+  - Implement `src/assets/capture.rs` to compute a compact set of capture view directions per mesh (biased hemisphere coverage); store projection params.
+  - Decide persistence format: in‑memory only initially; optional sidecar via `src/bin/capture_gen.rs` writing JSON under `data/`.
+  - Tests: parameterization maps surface points to tile domain with low distortion on primitives.
+
+- Atlas + recapture
+  - Implement `atlas.rs` with fixed‑size page allocator and RGBA16F textures (attributes or radiance; start with attributes).
+  - Implement `recapture.rs` with budgets (tiles/frame, bytes/frame) and priority scoring (distance, motion, age, TOD changes).
+  - Implement `capture.wgsl` to render G‑Buffer‑like attributes from the tile’s view into the atlas.
+
+- Sampling
+  - Implement `sampling.rs`: select best tile (normal alignment + proximity), project hit to tile space, fetch attributes/radiance.
+  - Integrate into `gi/ssgi.rs` and `reflections/ssr.rs` miss paths.
+
+- Tooling
+  - Implement `capture_viz.rs` to draw per‑mesh tile quads/directions in world; draw counts on HUD.
+  - Implement `atlas_inspector.rs` to show atlas pages/mips and residency heatmap.
+
+- Integration and config
+  - Extend `LightingConfig` with atlas size, tiles per frame, capture mode (attributes vs radiance), and invalidation thresholds for sun/sky.
+  - Update `src/README.md` for all new modules and tools.
+
+Suggested formats
+- Atlas textures: `RGBA16F` for attributes (albedo.rgb + rough/metal packed) or radiance; separate normal/roughness targets optional later.
+
+Tests
+- Assets: property tests for projection to tile domain; coverage on simple meshes (cube/plane).
+- Runtime: deterministic budgeted recapture order with fixed camera path; assert steady residency counts.
+
+Out of scope
+- Triangle BVH/SDF tracing (Lightning M3).
+- Multi‑bounce GI and denoisers (Lightning M4).
+
+Housekeeping
+- Keep docblocks at top of new modules per repo guidelines.
+- If adding any crates for JSON sidecars or tooling, use `cargo add` and document rationale.
+

--- a/docs/issues/Lightning_M4.md
+++ b/docs/issues/Lightning_M4.md
@@ -1,0 +1,66 @@
+Title: Lightning M4 — Multi‑bounce Indirect, Denoisers, and Debug Tooling
+
+Goal
+- Improve GI quality and stability via multi‑bounce propagation and denoisers tailored to diffuse GI and specular reflections. Ship overlays for capture tiles/atlas and ray debugging to make tuning feasible.
+
+Scope
+- Add a lightweight indirect radiance accumulation layer with trickle updates (one extra bounce per frame). Add temporal‑first denoisers with small spatial filters. Build debug overlays for tiles/atlas/rays. Finalize perf dials.
+
+Planned files and module map (aligned with src/README.md)
+- Indirect radiance and propagation
+  - `src/gfx/gi/radiance.rs` — Indirect radiance buffers/history and write‑back from gathers.
+  - `src/gfx/gi/propagate.comp.wgsl` — Compute pass to propagate one extra bounce per frame.
+
+- Denoisers
+  - `src/gfx/denoise/gi.rs` — Temporal‑first denoiser for diffuse GI; small spatial pass with normal/depth guides.
+  - `src/gfx/denoise/reflections.rs` — Temporal‑first denoiser for reflections; roughness‑aware spatial kernel.
+  - `src/gfx/denoise/gi_denoise.comp.wgsl` and `src/gfx/denoise/reflections_denoise.comp.wgsl` — Compute shaders.
+
+- Debug tooling
+  - `src/gfx/debug/rays.rs` — First‑hit buffers, miss reason visualization (off‑screen, thin geo, budget cap).
+  - Reuse/extend: `src/gfx/debug/capture_viz.rs`, `src/gfx/debug/atlas_inspector.rs` (from Lightning M2).
+
+- Integration
+  - `src/gfx/pipeline.rs` — Pipelines/bind groups for denoisers and propagation.
+  - `src/gfx/mod.rs` — Frame graph order: gather -> write‑back -> propagate -> denoise -> composite.
+
+Connections to existing hierarchy (read src/README.md)
+- Works with G‑Buffer, Hi‑Z, temporal history from M1; capture atlas and RT paths from M2/M3.
+- Update `src/README.md` sections under `gfx/` to describe radiance cache, denoisers, and debug overlays.
+
+Acceptance criteria
+- Indirect lighting shows visible extra bounce indoors as frames accumulate, without large flicker.
+- Denoisers reduce shimmer in GI and reflections; temporal stability maintained during slow camera motion.
+- Overlays render: tile placement, atlas residency heatmaps, and ray first‑hit/miss reasons.
+- Perf dials exposed to tweak budgets, denoiser strength, and propagation cadence.
+
+Detailed tasks
+- Radiance accumulation and propagation
+  - Implement `gi/radiance.rs` buffers and history; define a compact format (e.g., RGBA16F) for accumulations.
+  - Implement `propagate.comp.wgsl` to push one additional bounce per frame; clamp via temporal history.
+
+- Denoisers
+  - Implement temporal reprojection hooks and clamping reuse; add small spatial kernels guided by normal/depth/shading rate.
+  - Expose parameters in `LightingConfig` (temporal alpha, clamp strength, spatial radius).
+
+- Debug overlays
+  - Implement `debug/rays.rs` showing first‑hit normal/depth and miss reason categories.
+  - Extend `capture_viz.rs` and `atlas_inspector.rs` with per‑tile age/invalidations and scheduler scores.
+
+- Integration and config
+  - Add perf dials to `LightingConfig`: radiance update budget, propagate cadence (frames/bounce), denoiser strengths.
+  - Update `src/README.md` to reflect modules and usage.
+
+Suggested formats
+- Radiance buffers: `RGBA16F` with exposure‑consistent accumulation; separate variance buffer optional.
+
+Tests
+- Temporal denoiser unit tests: clamp behavior on synthetic step edges; variance reduction sanity.
+- Radiance propagation: energy doesn’t explode for a closed box test; monotonic convergence under bounded albedo.
+
+Out of scope
+- Hardware RT integration; path‑traced modes; translucency refraction.
+
+Housekeeping
+- Keep module docblocks and rustdoc complete; ensure `clippy` clean.
+


### PR DESCRIPTION
- Remove duplicate HashMap import and duplicate zombie HP bar block
- Fix zombie facing code to use per-instance forward offsets
- Remove unreachable Space key arms; keep clear PC-cast vs sky-toggle paths
- Deduplicate PC transform code; resolve unused var warning

Build: cargo check; Clippy: -D warnings; Tests: all passing
