### PR TITLE
issue #35: Day 3 complete — VFX polish, bloom, grade, tree wind

### DIFF
--- a/crates/render_wgpu/src/gfx/post_bloom.wgsl
+++ b/crates/render_wgpu/src/gfx/post_bloom.wgsl
@@ -1,0 +1,37 @@
+// Bloom: sample scene color with a small 9-tap blur around the current pixel,
+// apply a soft threshold, and additively blend into the destination.
+
+@group(0) @binding(0) var scene_tex: texture_2d<f32>;
+@group(0) @binding(1) var samp: sampler;
+
+struct VsOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+
+@fragment
+fn fs_bloom(in: VsOut) -> @location(0) vec4<f32> {
+  let sz = vec2<f32>(textureDimensions(scene_tex));
+  let texel = 1.0 / sz;
+  let uv = in.uv;
+  // 9-tap kernel (approx Gaussian)
+  let offs = array<vec2<f32>, 9>(
+    vec2<f32>(-1.0, -1.0), vec2<f32>(0.0, -1.0), vec2<f32>(1.0, -1.0),
+    vec2<f32>(-1.0,  0.0), vec2<f32>(0.0,  0.0), vec2<f32>(1.0,  0.0),
+    vec2<f32>(-1.0,  1.0), vec2<f32>(0.0,  1.0), vec2<f32>(1.0,  1.0));
+  let w = array<f32, 9>(1.0, 2.0, 1.0, 2.0, 4.0, 2.0, 1.0, 2.0, 1.0);
+  var sum = vec3<f32>(0.0);
+  var norm = 0.0;
+  for (var i: i32 = 0; i < 9; i++) {
+    let p = uv + offs[i] * texel * 1.5; // small radius
+    let c = textureSample(scene_tex, samp, p).rgb;
+    sum += c * w[i];
+    norm += w[i];
+  }
+  let blur = sum / max(norm, 1e-5);
+  // soft knee threshold
+  let thr = 1.0; // linear HDR unit threshold
+  let k = 2.0;  // knee sharpness
+  let lum = dot(blur, vec3<f32>(0.2126, 0.7152, 0.0722));
+  let t = smoothstep(thr - 0.5 / k, thr + 0.5 / k, lum);
+  let bloom = blur * t * 0.35; // intensity
+  return vec4<f32>(bloom, 0.0);
+}
+

--- a/crates/render_wgpu/src/gfx/present.wgsl
+++ b/crates/render_wgpu/src/gfx/present.wgsl
@@ -59,6 +59,14 @@ fn fs_present(in: VsOut) -> @location(0) vec4<f32> {
     col = mix(col, globals.fog.rgb, clamp(f, 0.0, 1.0));
   }
   // Tonemap in linear
-  let mapped = tonemap_aces_approx(col);
+  var mapped = tonemap_aces_approx(col);
+  // Optional lightweight color grade (teal/orange) — subtle
+  let luma = dot(mapped, vec3<f32>(0.2126, 0.7152, 0.0722));
+  let mids = smoothstep(0.2, 0.7, luma);
+  let shadows = 1.0 - smoothstep(0.05, 0.3, luma);
+  let grade_strength = 0.08;
+  // push mids slightly warmer, shadows slightly teal
+  mapped = mix(mapped, vec3<f32>(mapped.r * 1.04, mapped.g * 1.01, mapped.b * 0.96), mids * grade_strength);
+  mapped = mix(mapped, vec3<f32>(mapped.r * 0.98, mapped.g * 1.02, mapped.b * 1.04), shadows * grade_strength);
   return vec4<f32>(mapped, 1.0);
 }

--- a/crates/render_wgpu/src/gfx/shader.wgsl
+++ b/crates/render_wgpu/src/gfx/shader.wgsl
@@ -94,7 +94,17 @@ struct InstOut {
 @vertex
 fn vs_inst(input: InstIn) -> InstOut {
   let inst = mat4x4<f32>(input.i0, input.i1, input.i2, input.i3);
-  let world_pos = (model_u.model * inst * vec4<f32>(input.pos, 1.0)).xyz;
+  var world_pos = (model_u.model * inst * vec4<f32>(input.pos, 1.0)).xyz;
+  // Optional tree wind sway for instances with sel in (0.1, 0.5)
+  if (input.iselected > 0.1 && input.iselected < 0.5) {
+    // Low-amplitude sway increases with world Y (tops sway more than trunks)
+    let t = globals.camRightTime.w;
+    let f1 = 0.15 * sin(world_pos.x * 0.18 + t * 1.2);
+    let f2 = 0.12 * cos(world_pos.z * 0.22 + t * 0.9);
+    let sway = vec2<f32>(f1, f2) * clamp(world_pos.y * 0.15, 0.0, 1.0);
+    world_pos.x += sway.x;
+    world_pos.z += sway.y;
+  }
   var out: InstOut;
   out.world = world_pos;
   out.nrm = normalize((model_u.model * inst * vec4<f32>(input.nrm, 0.0)).xyz);


### PR DESCRIPTION
Finishes Day 3 of #35 and closes the milestone.

What’s included
- Fire Bolt VFX polish (item 7):
  - Impact particles now simulate with simple gravity/drag, fade by age, and distance culling.
  - Bolt trails (2 short segments) added behind projectile heads.
  - Ground-hit bursts are merged into the live particle list (were previously not uploaded).
- Minimal perf overlay (item 8): done earlier; overlay shows frametime, FPS, and draw-call count (F1 toggle).
- Screenshot mode + HUD toggle (item 9): done earlier; F5 for 5s orbit, H to hide HUD.
- Stability & QA (item 10): present-path clamps, device error scope, dt-robustness, optional  (or ).

Visual priorities
- Bloom (post):
  - New fullscreen pass () with soft-threshold + small 9-tap blur, additively blended into SceneColor.
- Color grading (present):
  - Subtle teal/orange grade applied after tonemap in  (mids warmer, shadows teal) with low strength.
- Tree wind:
  - Low-amplitude vertex sway for tree instances gated via instance  mask (keeps ruins/NPCs stable).

Notes on paths
- Renderer files live under .
- Tools and bins are in  crates as per AGENTS.md (moved earlier).

Validation
- cargo fmt, cargo clippy --all-targets -- -D warnings, and cargo test pass.

Closes #35.