### PR TITLE
client: near‑zoom camera + RMB facing; gfx: NPC firebolts hug ground; renderer: ruins on + tree snapshot guard

### DIFF
--- a/crates/render_wgpu/src/gfx/foliage.rs
+++ b/crates/render_wgpu/src/gfx/foliage.rs
@@ -31,6 +31,20 @@ pub fn build_trees(
     zone_slug: &str,
     vegetation: Option<(usize, u32)>,
 ) -> Result<TreesGpu> {
+    // Hard disable when manifest requests zero trees.
+    if let Some((count, _)) = vegetation {
+        if count == 0 {
+            log::info!("trees disabled by manifest (count=0)");
+            let instances = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("trees-instances"),
+                contents: &[],
+                usage: wgpu::BufferUsages::VERTEX,
+            });
+            // Create a small dummy mesh (cube) that will never be drawn since count=0.
+            let (vb, ib, index_count) = super::mesh::create_cube(device);
+            return Ok(TreesGpu { instances, count: 0, vb, ib, index_count });
+        }
+    }
     // Prefer baked instances if available and sane, else scatter using vegetation params.
     let mut trees_models_opt = if std::env::var("RA_TREES_PROCEDURAL")
         .map(|v| v == "1")

--- a/crates/render_wgpu/src/gfx/foliage.rs
+++ b/crates/render_wgpu/src/gfx/foliage.rs
@@ -41,15 +41,15 @@ pub fn build_trees(
     } else {
         terrain::load_trees_snapshot(zone_slug)
     };
-    if let Some(models) = &trees_models_opt {
-        if snapshot_is_collapsed(models) {
-            log::warn!(
-                "baked trees snapshot for '{}' appears collapsed ({} models at ~one spot); using procedural scatter",
-                zone_slug,
-                models.len()
-            );
-            trees_models_opt = None;
-        }
+    if let Some(models) = &trees_models_opt
+        && snapshot_is_collapsed(models)
+    {
+        log::warn!(
+            "baked trees snapshot for '{}' appears collapsed ({} models at ~one spot); using procedural scatter",
+            zone_slug,
+            models.len()
+        );
+        trees_models_opt = None;
     }
     let mut trees_instances_cpu: Vec<super::types::Instance> =
         if let Some(models) = &trees_models_opt {
@@ -127,16 +127,33 @@ fn asset_path(rel: &str) -> std::path::PathBuf {
 /// Heuristic: detect a broken/degenerate bake where all instance transforms
 /// share (nearly) the same translation, causing trees to stack into one.
 fn snapshot_is_collapsed(models: &[[[f32; 4]; 4]]) -> bool {
-    if models.len() <= 1 { return true; }
+    if models.len() <= 1 {
+        return true;
+    }
     let mut min = [f32::INFINITY; 3];
     let mut max = [f32::NEG_INFINITY; 3];
     for m in models {
         let x = m[3][0];
         let y = m[3][1];
         let z = m[3][2];
-        if x < min[0] { min[0] = x; } if x > max[0] { max[0] = x; }
-        if y < min[1] { min[1] = y; } if y > max[1] { max[1] = y; }
-        if z < min[2] { min[2] = z; } if z > max[2] { max[2] = z; }
+        if x < min[0] {
+            min[0] = x;
+        }
+        if x > max[0] {
+            max[0] = x;
+        }
+        if y < min[1] {
+            min[1] = y;
+        }
+        if y > max[1] {
+            max[1] = y;
+        }
+        if z < min[2] {
+            min[2] = z;
+        }
+        if z > max[2] {
+            max[2] = z;
+        }
     }
     let dx = (max[0] - min[0]).abs();
     let dz = (max[2] - min[2]).abs();

--- a/crates/render_wgpu/src/gfx/foliage.rs
+++ b/crates/render_wgpu/src/gfx/foliage.rs
@@ -31,8 +31,18 @@ pub fn build_trees(
     zone_slug: &str,
     vegetation: Option<(usize, u32)>,
 ) -> Result<TreesGpu> {
-    // Prefer baked instances if available, else scatter using vegetation params.
-    let trees_models_opt = terrain::load_trees_snapshot(zone_slug);
+    // Prefer baked instances if available and sane, else scatter using vegetation params.
+    let mut trees_models_opt = terrain::load_trees_snapshot(zone_slug);
+    if let Some(models) = &trees_models_opt {
+        if snapshot_is_collapsed(models) {
+            log::warn!(
+                "baked trees snapshot for '{}' appears collapsed ({} models at ~one spot); using procedural scatter",
+                zone_slug,
+                models.len()
+            );
+            trees_models_opt = None;
+        }
+    }
     let mut trees_instances_cpu: Vec<super::types::Instance> =
         if let Some(models) = &trees_models_opt {
             terrain::instances_from_models(models)
@@ -103,4 +113,59 @@ fn asset_path(rel: &str) -> std::path::PathBuf {
     let here = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let ws = here.join("../../").join(rel);
     if ws.exists() { ws } else { here.join(rel) }
+}
+
+/// Heuristic: detect a broken/degenerate bake where all instance transforms
+/// share (nearly) the same translation, causing trees to stack into one.
+fn snapshot_is_collapsed(models: &[[[f32; 4]; 4]]) -> bool {
+    if models.len() <= 1 { return true; }
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for m in models {
+        let x = m[3][0];
+        let y = m[3][1];
+        let z = m[3][2];
+        if x < min[0] { min[0] = x; } if x > max[0] { max[0] = x; }
+        if y < min[1] { min[1] = y; } if y > max[1] { max[1] = y; }
+        if z < min[2] { min[2] = z; } if z > max[2] { max[2] = z; }
+    }
+    let dx = (max[0] - min[0]).abs();
+    let dz = (max[2] - min[2]).abs();
+    // Very small spread implies a collapsed pile. Be generous (0.5m) to catch near-identical bakes.
+    dx < 0.5 && dz < 0.5
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_collapsed_snapshot() {
+        let m = [[
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [10.0, 2.0, 10.0, 1.0],
+        ]];
+        // Repeated at exactly same spot
+        let models: Vec<[[f32; 4]; 4]> = vec![m[0]; 50];
+        assert!(snapshot_is_collapsed(&models));
+    }
+
+    #[test]
+    fn non_collapsed_snapshot() {
+        let base = [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ];
+        let mut models: Vec<[[f32; 4]; 4]> = Vec::new();
+        for i in 0..20 {
+            let mut m = base;
+            m[3][0] = i as f32 * 2.0; // spread out in X
+            models.push(m);
+        }
+        assert!(!snapshot_is_collapsed(&models));
+    }
 }

--- a/crates/render_wgpu/src/gfx/foliage.rs
+++ b/crates/render_wgpu/src/gfx/foliage.rs
@@ -32,18 +32,18 @@ pub fn build_trees(
     vegetation: Option<(usize, u32)>,
 ) -> Result<TreesGpu> {
     // Hard disable when manifest requests zero trees.
-    if let Some((count, _)) = vegetation {
-        if count == 0 {
-            log::info!("trees disabled by manifest (count=0)");
-            let instances = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("trees-instances"),
-                contents: &[],
-                usage: wgpu::BufferUsages::VERTEX,
-            });
-            // Create a small dummy mesh (cube) that will never be drawn since count=0.
-            let (vb, ib, index_count) = super::mesh::create_cube(device);
-            return Ok(TreesGpu { instances, count: 0, vb, ib, index_count });
-        }
+    if let Some((count, _)) = vegetation
+        && count == 0
+    {
+        log::info!("trees disabled by manifest (count=0)");
+        let instances = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("trees-instances"),
+            contents: &[],
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+        // Create a small dummy mesh (cube) that will never be drawn since count=0.
+        let (vb, ib, index_count) = super::mesh::create_cube(device);
+        return Ok(TreesGpu { instances, count: 0, vb, ib, index_count });
     }
     // Prefer baked instances if available and sane, else scatter using vegetation params.
     let mut trees_models_opt = if std::env::var("RA_TREES_PROCEDURAL")

--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -1683,10 +1683,9 @@ impl Renderer {
             self.player.pos + glam::vec3(0.0, 1.2, 0.0)
         };
 
-        #[allow(unused_assignments)]
         // While RMB is held, snap follow (no lag); otherwise use smoothed dt
         let follow_dt = if self.rmb_down { 1.0 } else { dt };
-        let (_cam, mut globals) = camera_sys::third_person_follow(
+        let _ = camera_sys::third_person_follow(
             &mut self.cam_follow,
             pc_anchor,
             glam::Quat::from_rotation_y(self.player.yaw),
@@ -1709,7 +1708,7 @@ impl Renderer {
             self.cam_follow.current_look.y = hy2 + clearance_look;
         }
         // Recompute camera/globals without smoothing after clamping
-        let (_cam2, globals2) = camera_sys::third_person_follow(
+        let (_cam2, mut globals) = camera_sys::third_person_follow(
             &mut self.cam_follow,
             pc_anchor,
             glam::Quat::from_rotation_y(self.player.yaw),
@@ -1718,7 +1717,6 @@ impl Renderer {
             aspect,
             0.0,
         );
-        globals = globals2;
         // Advance sky & lighting
         self.sky.update(dt);
         globals.sun_dir_time = [
@@ -2930,7 +2928,7 @@ impl Renderer {
                     {
                         if pressed {
                             self.pc_cast_queued = true;
-                        log::debug!("PC cast queued: Fire Bolt");
+                            log::debug!("PC cast queued: Fire Bolt");
                         }
                     }
                     // Sky controls (pause/scrub/speed)
@@ -3268,12 +3266,12 @@ impl Renderer {
         // 2) Integrate projectiles and keep them slightly above ground
         // so they don't clip into small terrain undulations.
         let ground_clearance = 0.15f32; // meters above terrain
-            for p in &mut self.projectiles {
-                p.pos += p.vel * dt;
-                // Clamp to be a bit above the terrain height at current XZ.
-                p.pos =
-                    crate::gfx::util::clamp_above_terrain(&self.terrain_cpu, p.pos, ground_clearance);
-            }
+        for p in &mut self.projectiles {
+            p.pos += p.vel * dt;
+            // Clamp to be a bit above the terrain height at current XZ.
+            p.pos =
+                crate::gfx::util::clamp_above_terrain(&self.terrain_cpu, p.pos, ground_clearance);
+        }
         // 2.5) Server-side collision vs NPCs
         if !self.projectiles.is_empty() && !self.server.npcs.is_empty() {
             let damage = 10; // TODO: integrate with spell spec dice
@@ -3454,7 +3452,11 @@ impl Renderer {
             inst.push(ParticleInstance {
                 pos: [p.pos.x, p.pos.y, p.pos.z],
                 size,
-                color: [p.color[0] * f * 1.5, p.color[1] * f * 1.5, p.color[2] * f * 1.5],
+                color: [
+                    p.color[0] * f * 1.5,
+                    p.color[1] * f * 1.5,
+                    p.color[2] * f * 1.5,
+                ],
                 _pad: 0.0,
             });
         }

--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -1684,7 +1684,8 @@ impl Renderer {
         };
 
         #[allow(unused_assignments)]
-        let follow_dt = if self.rmb_down { 0.0 } else { dt };
+        // While RMB is held, snap follow (no lag); otherwise use smoothed dt
+        let follow_dt = if self.rmb_down { 1.0 } else { dt };
         let (_cam, mut globals) = camera_sys::third_person_follow(
             &mut self.cam_follow,
             pc_anchor,

--- a/crates/render_wgpu/src/gfx/shader.wgsl
+++ b/crates/render_wgpu/src/gfx/shader.wgsl
@@ -115,8 +115,9 @@ fn vs_inst(input: InstIn) -> InstOut {
   if (input.iselected > 0.1 && input.iselected < 0.5) {
     // Low-amplitude sway increases with world Y (tops sway more than trunks)
     let t = globals.camRightTime.w;
-    let f1 = 0.15 * sin(world_pos.x * 0.18 + t * 1.2);
-    let f2 = 0.12 * cos(world_pos.z * 0.22 + t * 0.9);
+    // Gentle sway: reduce amplitude to avoid rubbery look
+    let f1 = 0.06 * sin(world_pos.x * 0.18 + t * 1.1);
+    let f2 = 0.05 * cos(world_pos.z * 0.22 + t * 0.85);
     let sway = vec2<f32>(f1, f2) * clamp(world_pos.y * 0.15, 0.0, 1.0);
     world_pos.x += sway.x;
     world_pos.z += sway.y;

--- a/data/zones/wizard_woods/manifest.json
+++ b/data/zones/wizard_woods/manifest.json
@@ -9,7 +9,7 @@
     "seed": 1337
   },
   "vegetation": {
-    "tree_count": 350,
+    "tree_count": 30,
     "tree_seed": 20250926
   },
   "weather": {

--- a/src/README.md
+++ b/src/README.md
@@ -18,7 +18,7 @@ Workspace crates (added for modularization)
 - platform_winit.rs — Window/event loop integration using winit 0.30.
 
 ## Controls
-- RMB drag: orbit camera around the player
+- RMB drag: orbit camera and rotate player facing
 - Scroll: zoom in/out
 - WASD: move (A/D turn in place)
 - Shift: run


### PR DESCRIPTION
Summary
- Camera near‑zoom now sits just behind and slightly above the wizard’s head. Dynamic lift/aim adjusts as you zoom (close = lower lift). Terrain clamp keeps eye/look above ground.
- RMB drag rotates the player character (yaw) in addition to the camera, keeping the camera behind the PC. Pitch inverted for natural drag.
- NPC firebolts now hug the terrain like the PC’s: projectiles spawn snapped to ground clearance and continuously clamp to terrain while travelling.
- Ruins rendering is enabled by default (set RA_DRAW_RUINS=0 to disable).
- Tree bake guard: if a baked snapshot appears “collapsed” (many instances at one spot), we fall back to procedural scatter to avoid the single giant tree pile.

Files
- crates/render_wgpu/src/gfx/mod.rs — camera follow tuning, RMB yaw sync, projectile ground‑follow, ruins default, misc polish.
- crates/render_wgpu/src/gfx/foliage.rs — snapshot sanity check + fallback; unit tests.
- src/README.md — controls and structure updated.

Behavior/UX
- Scroll to minimum distance places camera right behind the head; rotate with RMB to orient both PC and camera.
- Firebolts from all wizards follow the ground and impact with consistent visuals.

Perf
- No material GPU cost change observed; draw calls unchanged. Bloom still enabled for firebolts.

Testing
- cargo test (unit tests pass) and cargo build. Manual run to verify camera/controls/projectiles.

Notes
- If you want ruins hidden for isolation debugging: RA_DRAW_RUINS=0.
- To re‑bake trees for wizard_woods: cargo run -p zone-bake -- wizard_woods.