### PR TITLE
ux: death overlay; press R to respawn; keep scene on death

### DIFF
--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -123,6 +123,7 @@ pub struct Renderer {
     ssgi_scene_bgl: wgpu::BindGroupLayout,
     ssr_depth_bgl: wgpu::BindGroupLayout,
     ssr_scene_bgl: wgpu::BindGroupLayout,
+    palettes_bgl: wgpu::BindGroupLayout,
     globals_bg: wgpu::BindGroup,
     post_ao_bg: wgpu::BindGroup,
     ssgi_globals_bg: wgpu::BindGroup,
@@ -313,6 +314,9 @@ pub struct Renderer {
     // UI capture helpers
     screenshot_start: Option<f32>,
 
+    // Death overlay button rect for click hit-testing: (x0, y0, x1, y1) in px
+    death_btn_rect: Option<(f32, f32, f32, f32)>,
+
     // Server state (NPCs/health)
     server: server_core::ServerState,
 
@@ -369,6 +373,119 @@ impl Renderer {
             }
         }
         log::info!("PC died; spectator camera engaged");
+    }
+
+    fn respawn(&mut self) {
+        // Rebuild scene and server similar to initial construction.
+        // 1) Rebuild wizard scene instances and reset player state
+        let terrain_extent = self.max_dim as f32 * 0.5;
+        let ruins_base_offset = 0.4f32;
+        let ruins_radius = 6.5f32;
+        let scene_build = scene::build_demo_scene(
+            &self.device,
+            &self.skinned_cpu,
+            terrain_extent,
+            Some(&self.terrain_cpu),
+            ruins_base_offset,
+            ruins_radius,
+        );
+        // Snap to terrain heights again
+        let mut wizard_models = scene_build.wizard_models.clone();
+        for m in &mut wizard_models {
+            let c = m.to_cols_array();
+            let x = c[12];
+            let z = c[14];
+            let (h, _n) = terrain::height_at(&self.terrain_cpu, x, z);
+            let pos = glam::vec3(x, h, z);
+            let (s, r, _t) = glam::Mat4::from_cols_array(&c).to_scale_rotation_translation();
+            *m = glam::Mat4::from_scale_rotation_translation(s, r, pos);
+        }
+        let mut wizard_instances_cpu = scene_build.wizard_instances_cpu.clone();
+        for (i, inst) in wizard_instances_cpu.iter_mut().enumerate() {
+            inst.model = wizard_models[i].to_cols_array_2d();
+        }
+        self.wizard_instances = self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("wizard-instances"),
+            contents: bytemuck::cast_slice(&wizard_instances_cpu),
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+        });
+        self.wizard_instances_cpu = wizard_instances_cpu;
+        self.wizard_models = wizard_models;
+        self.wizard_count = self.wizard_instances_cpu.len() as u32;
+        self.wizard_anim_index = scene_build.wizard_anim_index;
+        self.wizard_time_offset = scene_build.wizard_time_offset;
+        self.wizard_last_phase = vec![0.0; self.wizard_count as usize];
+
+        // 2) Reset player and camera
+        let pc_initial_pos = {
+            let m = scene_build.wizard_models[scene_build.pc_index];
+            let c = m.to_cols_array();
+            glam::vec3(c[12], c[13], c[14])
+        };
+        self.pc_index = scene_build.pc_index;
+        self.player = client_core::controller::PlayerController::new(pc_initial_pos);
+        self.input.clear();
+        self.cam_follow = camera_sys::FollowState {
+            current_pos: glam::vec3(0.0, 5.0, -10.0),
+            current_look: scene_build.cam_target,
+        };
+        self.cam_orbit_yaw = 0.0;
+        self.cam_orbit_pitch = 0.2;
+        self.cam_distance = 8.5;
+        self.cam_lift = 3.5;
+        self.cam_look_height = 1.6;
+        self.rmb_down = false;
+        self.last_cursor_pos = None;
+        self.death_btn_rect = None;
+        self.pc_cast_queued = false;
+        self.pc_anim_start = None;
+        self.pc_cast_fired = false;
+
+        // Reset HP and alive flag
+        self.wizard_hp = vec![self.wizard_hp_max; self.wizard_count as usize];
+        self.pc_alive = true;
+
+        // 3) Reset server and zombies
+        let npcs = npcs::build(&self.device, terrain_extent);
+        self.npc_vb = npcs.vb;
+        self.npc_ib = npcs.ib;
+        self.npc_index_count = npcs.index_count;
+        self.npc_instances = npcs.instances;
+        self.npc_models = npcs.models;
+        self.server = npcs.server;
+        let (zinst, zcpu, zmodels, zids, zcount) =
+            zombies::build_instances(&self.device, &self.terrain_cpu, &self.server, self.zombie_joints);
+        self.zombie_instances = zinst;
+        self.zombie_instances_cpu = zcpu;
+        self.zombie_models = zmodels.clone();
+        self.zombie_ids = zids;
+        self.zombie_count = zcount;
+        self.zombie_prev_pos = zmodels
+            .iter()
+            .map(|m| glam::vec3(m.to_cols_array()[12], m.to_cols_array()[13], m.to_cols_array()[14]))
+            .collect();
+        self.zombie_forward_offsets = vec![zombies::forward_offset(&self.zombie_cpu); self.zombie_count as usize];
+        // Recreate zombie palette buffer sized for new count
+        let total_z_mats = self.zombie_count as usize * self.zombie_joints as usize;
+        self.zombie_palettes_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("zombie-palettes"),
+            size: (total_z_mats * 64) as u64,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        self.zombie_palettes_bg = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("zombie-palettes-bg"),
+            layout: &self.palettes_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: self.zombie_palettes_buf.as_entire_binding(),
+            }],
+        });
+
+        // 4) Clear FX
+        self.projectiles.clear();
+        self.particles.clear();
+        log::info!("Respawn complete");
     }
     fn remove_wizard_at(&mut self, idx: usize) {
         if idx >= self.wizard_count as usize {
@@ -1299,6 +1416,7 @@ impl Renderer {
             ssgi_scene_bgl: ssgi_scene_bgl.clone(),
             ssr_depth_bgl: ssr_depth_bgl.clone(),
             ssr_scene_bgl: ssr_scene_bgl.clone(),
+            palettes_bgl: palettes_bgl.clone(),
             globals_bg,
             post_ao_bg,
             ssgi_globals_bg,
@@ -1424,6 +1542,7 @@ impl Renderer {
             rmb_down: false,
             last_cursor_pos: None,
             screenshot_start: None,
+            death_btn_rect: None,
 
             npc_vb,
             npc_ib,
@@ -1676,10 +1795,15 @@ impl Renderer {
         );
         #[allow(unused_assignments)]
         // Anchor camera to the center of the PC model, not the feet.
-        let pc_anchor = if self.pc_index < self.wizard_models.len() {
-            let m = self.wizard_models[self.pc_index];
-            (m * glam::Vec4::new(0.0, 1.2, 0.0, 1.0)).truncate()
+        let pc_anchor = if self.pc_alive {
+            if self.pc_index < self.wizard_models.len() {
+                let m = self.wizard_models[self.pc_index];
+                (m * glam::Vec4::new(0.0, 1.2, 0.0, 1.0)).truncate()
+            } else {
+                self.player.pos + glam::vec3(0.0, 1.2, 0.0)
+            }
         } else {
+            // When dead, keep camera around the last known player position instead of the hidden model.
             self.player.pos + glam::vec3(0.0, 1.2, 0.0)
         };
 
@@ -2436,12 +2560,17 @@ impl Renderer {
             // No GCD overlay when using cast-time only
             let gcd_frac = 0.0f32;
             // HUD (default on; set RA_OVERLAYS=0 to hide)
-            if std::env::var("RA_OVERLAYS")
+            let overlays_disabled = std::env::var("RA_OVERLAYS")
                 .map(|v| v == "0")
-                .unwrap_or(false)
-            {
-                // disabled
-            } else {
+                .unwrap_or(false);
+            if !self.pc_alive {
+                // Show death overlay regardless of RA_OVERLAYS setting
+                self.hud.reset();
+                let rect = self
+                    .hud
+                    .death_overlay(self.size.width, self.size.height, "You died.", "Respawn");
+                self.death_btn_rect = Some(rect);
+            } else if !overlays_disabled {
                 self.hud.build(
                     self.size.width,
                     self.size.height,
@@ -2457,9 +2586,10 @@ impl Renderer {
                     self.hud
                         .append_perf_text(self.size.width, self.size.height, &line);
                 }
-                self.hud.queue(&self.device, &self.queue);
-                self.hud.draw(&mut encoder, &view);
             }
+            // Queue+draw HUD (either normal or death overlay)
+            self.hud.queue(&self.device, &self.queue);
+            self.hud.draw(&mut encoder, &view);
             self.queue.submit(Some(encoder.finish()));
             frame.present();
         }
@@ -3016,23 +3146,38 @@ impl Renderer {
                     if !self.rmb_down {
                         self.last_cursor_pos = None; // reset deltas
                     }
+                } else if *button == winit::event::MouseButton::Left
+                    && state.is_pressed() && !self.pc_alive
+                {
+                    // Hit-test respawn button if visible
+                    if let (Some((mx, my)), Some((x0, y0, x1, y1))) =
+                        (self.last_cursor_pos, self.death_btn_rect)
+                    {
+                        let x = mx as f32;
+                        let y = my as f32;
+                        if x >= x0 && x <= x1 && y >= y0 && y <= y1 {
+                            log::info!("Respawn clicked");
+                            self.respawn();
+                        }
+                    }
                 }
             }
             WindowEvent::CursorMoved { position, .. } => {
-                if self.rmb_down {
-                    if let Some((lx, ly)) = self.last_cursor_pos {
-                        let dx = position.x - lx;
-                        let dy = position.y - ly;
-                        let sens = 0.005;
-                        // Fully sync player facing with mouse drag; keep camera behind the player
-                        let yaw_delta = dx as f32 * sens;
-                        self.player.yaw = wrap_angle(self.player.yaw - yaw_delta);
-                        self.cam_orbit_yaw = 0.0;
-                        // Invert pitch control (mouse up pitches camera down, and vice versa)
-                        self.cam_orbit_pitch =
-                            (self.cam_orbit_pitch + dy as f32 * sens).clamp(-0.6, 1.2);
-                    }
-                    self.last_cursor_pos = Some((position.x, position.y));
+                // Track last cursor position for button hit-testing
+                self.last_cursor_pos = Some((position.x, position.y));
+                if self.rmb_down
+                    && let Some((lx, ly)) = self.last_cursor_pos
+                {
+                    let dx = position.x - lx;
+                    let dy = position.y - ly;
+                    let sens = 0.005;
+                    // Fully sync player facing with mouse drag; keep camera behind the player
+                    let yaw_delta = dx as f32 * sens;
+                    self.player.yaw = wrap_angle(self.player.yaw - yaw_delta);
+                    self.cam_orbit_yaw = 0.0;
+                    // Invert pitch control (mouse up pitches camera down, and vice versa)
+                    self.cam_orbit_pitch =
+                        (self.cam_orbit_pitch + dy as f32 * sens).clamp(-0.6, 1.2);
                 }
             }
             WindowEvent::Focused(false) => {

--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -310,6 +310,8 @@ pub struct Renderer {
     cam_look_height: f32,
     rmb_down: bool,
     last_cursor_pos: Option<(f64, f64)>,
+    // Window scale factor (DPI). Used to convert logical cursor coords → physical px.
+    window_scale: f64,
 
     // UI capture helpers
     screenshot_start: Option<f32>,
@@ -436,6 +438,7 @@ impl Renderer {
         self.cam_look_height = 1.6;
         self.rmb_down = false;
         self.last_cursor_pos = None;
+        self.window_scale = self.window_scale.max(1.0); // keep prior scale if known
         self.death_btn_rect = None;
         self.pc_cast_queued = false;
         self.pc_anim_start = None;
@@ -1541,6 +1544,7 @@ impl Renderer {
             cam_look_height: 1.6,
             rmb_down: false,
             last_cursor_pos: None,
+            window_scale: 1.0,
             screenshot_start: None,
             death_btn_rect: None,
 
@@ -3186,8 +3190,11 @@ impl Renderer {
                     self.cam_orbit_pitch =
                         (self.cam_orbit_pitch + dy as f32 * sens).clamp(-0.6, 1.2);
                 }
-                // Track last cursor position for button hit-testing
-                self.last_cursor_pos = Some((position.x, position.y));
+                // Track last cursor position in PHYSICAL px for button hit-testing
+                self.last_cursor_pos = Some((position.x * self.window_scale, position.y * self.window_scale));
+            }
+            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                self.window_scale = *scale_factor;
             }
             WindowEvent::Focused(false) => {
                 // Clear sticky keys when window loses focus

--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -3123,6 +3123,13 @@ impl Renderer {
                             log::info!("Screenshot mode: 5s orbit starting");
                         }
                     }
+                    // Allow keyboard respawn as fallback when dead
+                    PhysicalKey::Code(KeyCode::KeyR) | PhysicalKey::Code(KeyCode::Enter) => {
+                        if pressed && !self.pc_alive {
+                            log::info!("Respawn via keyboard");
+                            self.respawn();
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -3163,10 +3170,10 @@ impl Renderer {
                 }
             }
             WindowEvent::CursorMoved { position, .. } => {
-                // Track last cursor position for button hit-testing
-                self.last_cursor_pos = Some((position.x, position.y));
+                // Use previous cursor for deltas, then update to current.
+                let prev = self.last_cursor_pos;
                 if self.rmb_down
-                    && let Some((lx, ly)) = self.last_cursor_pos
+                    && let Some((lx, ly)) = prev
                 {
                     let dx = position.x - lx;
                     let dy = position.y - ly;
@@ -3179,6 +3186,8 @@ impl Renderer {
                     self.cam_orbit_pitch =
                         (self.cam_orbit_pitch + dy as f32 * sens).clamp(-0.6, 1.2);
                 }
+                // Track last cursor position for button hit-testing
+                self.last_cursor_pos = Some((position.x, position.y));
             }
             WindowEvent::Focused(false) => {
                 // Clear sticky keys when window loses focus

--- a/crates/render_wgpu/src/gfx/ui.rs
+++ b/crates/render_wgpu/src/gfx/ui.rs
@@ -1605,15 +1605,14 @@ impl Hud {
         self.text_vcount = self.text_verts.len() as u32;
     }
 
-    /// Draw a simple death overlay with centered message and a button.
-    /// Returns button rect in px as (x0, y0, x1, y1) for hit testing.
+    /// Draw a simple death overlay with centered messages.
     pub fn death_overlay(
         &mut self,
         surface_w: u32,
         surface_h: u32,
         title: &str,
-        button_text: &str,
-    ) -> (f32, f32, f32, f32) {
+        helper_text: &str,
+    ) {
         self.bars_verts.clear();
         self.text_verts.clear();
         // Dim background
@@ -1662,41 +1661,16 @@ impl Hud {
             y0 + 60.0,
             [1.0, 0.3, 0.25, 1.0],
         );
-        // Button
-        let btn_w = 160.0f32;
-        let btn_h = 36.0f32;
-        let bx0 = cx - btn_w * 0.5;
-        let by0 = y1 - 60.0 - btn_h * 0.5 + btn_h * 0.5; // a bit above bottom of panel
-        let bx1 = cx + btn_w * 0.5;
-        let by1 = by0 + btn_h;
-        self.push_rect(
-            surface_w,
-            surface_h,
-            bx0 - 2.0,
-            by0 - 2.0,
-            bx1 + 2.0,
-            by1 + 2.0,
-            [0.02, 0.02, 0.02, 0.95],
-        );
-        self.push_rect(
-            surface_w,
-            surface_h,
-            bx0,
-            by0,
-            bx1,
-            by1,
-            [0.18, 0.18, 0.18, 0.95],
-        );
+        // Helper text: e.g., "Press R to respawn"
         self.append_center_text(
             surface_w,
             surface_h,
-            button_text,
-            by0 + btn_h - 10.0,
+            helper_text,
+            y1 - 40.0,
             [0.95, 0.98, 1.0, 0.95],
         );
         self.bars_vcount = self.bars_verts.len() as u32;
         self.text_vcount = self.text_verts.len() as u32;
-        (bx0, by0, bx1, by1)
     }
 
     /// Append a single-line perf overlay in the top-left corner.

--- a/docs/magic-missile.md
+++ b/docs/magic-missile.md
@@ -1,0 +1,231 @@
+# Magic Missile (SRD 5.2.1) — Implementation Spec
+
+Scope: map the SRD 5.2.1 Magic Missile spell into deterministic, simulation‑friendly data and events aligned with our `sim_core` and `data_runtime` patterns (see `docs/fire_bolt.md` for the template). This document proposes schema and system updates needed for multi‑hit, auto‑hit spells and slot‑level scaling.
+
+—
+
+## A) Rules Facts (SRD 5.2.1)
+
+- Name: Magic Missile
+- School/Level: Evocation 1 (Wizard, Sorcerer)
+- Casting Time: Action
+- Range: 120 ft
+- Components: V, S
+- Duration: Instantaneous
+- Effect: Create three glowing darts of magical force. Each dart hits a creature you can see within range, dealing 1d4 + 1 Force damage. The darts strike simultaneously. You can direct them to hit one creature or several.
+- Higher Levels: +1 dart for each slot level above 1.
+
+Note: Facts above restated from SRD 5.2.1 for implementation; attribution lives in `NOTICE`.
+
+—
+
+## B) Sim‑Engine Contract (proposed)
+
+Identity & tags
+- `id`: `"wiz.magic_missile.srd521"`
+- `name`: `"Magic Missile"`
+- `source`: `"SRD 5.2.1"`
+- `school`: `"evocation"`, `level`: `1`
+- `classes`: `["wizard","sorcerer"]`
+- `tags`: `["auto-hit","multi-hit","force","projectile-optional","negated-by-shield"]`
+
+Cast, queueing, cooldowns
+- `cast_time_s`: `1.0` (Action; 1.0 s pacing)
+- `gcd_s`: `1.0`
+- `cooldown_s`: `0.0`
+- `resource_cost`: `none`
+- `can_move_while_casting`: `false`
+
+Targeting & LoS
+- `targeting`: `"unit"` (single selection in current HUD); engine will support multi‑target distribution policy for darts (see below).
+- `requires_line_of_sight`: `true`
+- `range_ft`: `120`, `minimum_range_ft`: `0`, `firing_arc_deg`: `180`
+
+Resolution model
+- `attack`: `none` (auto‑hit; no attack roll)
+- `save`: `none`
+- Multi‑hit instances: per SRD: 3 darts at slot level 1; +1 dart per slot above 1.
+- Each instance (dart) deals `1d4 + 1` Force. Darts hit simultaneously; apply all damage in the same tick.
+- Shield interaction: If the target has an available Shield reaction, it negates Magic Missile. We should model this as a reaction hook at damage time for abilities with a `negated_by_reaction = "shield"` hint (details below).
+
+Damage & scaling (proposed schema changes)
+- Extend `DamageSpec` or add `MultiHitSpec` to express per‑instance dice and a flat bonus:
+  - `per_instance.dice`: `"1d4"`
+  - `per_instance.flat_bonus`: `1`
+  - `instances`: `{ base: 3, per_slot_above: 1 }`
+  - `type`: `"force"`
+- Alternatively, as a stop‑gap, support `NdM+K` dice grammar so a single pending damage can use `"3d4+3"` at slot 1, `"4d4+4"` at slot 2, etc. This is less expressive (can’t distribute hits across targets) but minimal.
+
+Slot level source
+- Add an optional `slot_level` to the cast context. Until we pass that through the sim, default `slot_level = level` (1) for Magic Missile.
+- For AI/autoplay, add a simple policy: prefer lowest slot sufficient (L1 by default), unless test harness overrides.
+
+Distribution policy (no new UI yet)
+- Default: focus current target; assign all darts to `actor.target` if present.
+- Optional auto‑spread: if `allow_multi_target = true` and there are ≥2 hostile valid targets, fill darts as: 1 → current target; remaining darts to nearest alive hostiles by distance. Deterministic tie‑break by actor id.
+- Future HUD: explicit dart allocation UI could set a per‑cast distribution vector.
+
+Event model (sim‑core bus)
+- `CastStarted(actor, spell_id, t)`
+- `CastCompleted(actor, spell_id, t)`
+- If we visualize darts: `ProjectileSpawned(actor, spell_id, dart_id, origin, dir, t)` repeated `instances` times; otherwise skip.
+- `HitResolved(dart_id?, target, hit=true, crit=false, roll=auto, t)` per dart
+- `DamageApplied(source, target, amount, type, t)` per dart
+- `ReactionUsed(target, "shield", t)` when Shield negates all incoming MM instances to that target
+
+VFX/SFX (viz stubs)
+- `vfx.dart`: `"magic_missile_dart"`, `vfx.impact`: `"magic_missile_pop"`
+- `sfx.cast`: `"magic_missile_cast"`, `sfx.impact`: `"magic_missile_hit"`
+
+—
+
+## C) JSON (recommended, requires schema additions)
+
+This format introduces `multihit` and per‑instance damage description. It keeps backward‑compatibility for existing spells.
+
+```json
+{
+  "id": "wiz.magic_missile.srd521",
+  "name": "Magic Missile",
+  "version": "1.0.0",
+  "source": "SRD 5.2.1",
+  "school": "evocation",
+  "level": 1,
+  "classes": ["wizard", "sorcerer"],
+  "tags": ["auto-hit", "multi-hit", "force", "negated-by-shield"],
+
+  "cast_time_s": 1.0,
+  "gcd_s": 1.0,
+  "cooldown_s": 0.0,
+  "resource_cost": null,
+  "can_move_while_casting": false,
+
+  "targeting": "unit",
+  "requires_line_of_sight": true,
+  "range_ft": 120,
+  "minimum_range_ft": 0,
+  "firing_arc_deg": 180,
+
+  "attack": null,
+  "save": null,
+
+  "damage": {
+    "type": "force",
+    "add_spell_mod_to_damage": false
+  },
+  "multihit": {
+    "per_instance": { "dice": "1d4", "flat_bonus": 1 },
+    "instances": { "base": 3, "per_slot_above": 1 },
+    "distribution": { "mode": "focus-current", "allow_multi_target": true },
+    "negated_by_reaction": "shield"
+  },
+
+  "projectile": { "enabled": false, "speed_mps": 0.0, "radius_m": 0.0, "gravity": 0.0, "collide_with": [], "spawn_offset_m": {"x":0,"y":0,"z":0} },
+
+  "events": ["CastStarted","CastCompleted","HitResolved","DamageApplied","ReactionUsed"],
+  "metrics": { "collect": ["casts","instances","damage_total","damage_mean"] },
+  "policy": { "role": "dps", "priority_index": 1 }
+}
+```
+
+Fallback JSON (works today if we extend dice grammar only)
+- Represent total as a single instance with aggregated dice: `3d4+3` at slot 1, `4d4+4` at slot 2, etc. This loses per‑target distribution but is useful as an interim.
+
+—
+
+## D) Engine Changes (small, focused)
+
+- `data_runtime::spell::SpellSpec`
+  - Add optional `multihit` struct:
+    - `per_instance: { dice: String, flat_bonus: i32 }`
+    - `instances: { base: u32, per_slot_above: u32 }`
+    - `distribution: { mode: String, allow_multi_target: bool }`
+    - `negated_by_reaction: Option<String>`
+  - Keep existing `damage` for type and common flags.
+
+- Dice parser in `SimState::roll_dice_str`
+  - Extend to support `NdM+K` (and `NdM-K`). This is broadly useful and makes JSON more expressive even outside Magic Missile.
+
+- `sim_core::sim::state::SimState`
+  - Add optional `slot_level` to a cast context. Short‑term: default to spell level (1) for Magic Missile.
+
+- `sim_core::systems::attack_roll`
+  - If `spec.attack.is_none()` and `spec.multihit.is_some()`: push `instances` entries to `pending_damage` (one per dart), instead of the current single entry. Set `crit=false`.
+
+- `sim_core::systems::damage`
+  - When resolving entries for a spell with `multihit`, compute `per_instance` damage as `roll("1d4") + flat_bonus`. Respect `damage.type == "force"` with no underwater halving.
+  - Apply all instance damages within the same tick (they already are, since we process the batch for that tick).
+  - Reaction hook: if the target has a ready Shield reaction and the incoming ability has `negated_by_reaction == "shield"`, consume reaction and negate the instance. If multiple instances target the same unit in the same tick, one reaction negates all of them (MM clause). Log `reaction_used` once.
+
+- Distribution (no UI):
+  - If `distribution.mode == "focus-current"`: all instances use `actor.target`.
+  - If `allow_multi_target == true` and there are extra darts with no explicit assignment: pick nearest alive hostile distinct targets until darts are exhausted; deterministic tie‑break by id.
+
+—
+
+## E) Notes & Defaults
+
+- Force damage: not subject to the current underwater fire halving. No resistances modeled yet.
+- Simultaneity: ensure no interleaving that could create multiple concentration checks from one JSON aggregate form inadvertently. With per‑instance entries, you will get separate concentration checks; that matches typical 5E rulings for multiple hits.
+- VFX: we can visualize darts later. For now, treat as instantaneous hits to keep parity with tests.
+- Logging: include `instances=N`, and per‑instance `dmg=X` in `damage_applied` lines for easier debugging.
+
+—
+
+## F) Minimal Unit Tests (deterministic)
+
+1) Base instances: slot 1, caster with target set. After `cast_completed`, `attack_roll::run` pushes 3 entries for `wiz.magic_missile.srd521`; `damage::run` reduces target HP by the sum of three `(1d4+1)` rolls.
+2) Slot scaling: slot 3 → 5 entries. Verify `pending_damage.len() == 5` before damage.
+3) Distribution (auto): two hostiles in range, no UI allocation. With 3 darts, first goes to current target, remaining to nearest other(s). Assert damage applied to both.
+4) Shield interaction: target has `wiz.shield.srd521` and `reaction_ready = true`. On first incoming MM instance, consume reaction, apply `shield_reaction` log, and apply zero damage from all darts to that target in this tick.
+5) Determinism: given fixed seed, sum of three `(1d4+1)` rolls is stable across runs.
+
+—
+
+## G) Incremental Path
+
+- Phase 1 (smallest): extend dice grammar to accept `NdM+K`; encode Magic Missile as a single‑target aggregate (`3d4+3` at slot 1). No Shield special‑case yet. This unblocks early playtests.
+- Phase 2: add `multihit` schema, per‑instance resolution, and distribution policy; add Shield negation hook.
+- Phase 3: HUD support for explicit dart allocation and optional dart VFX.
+
+—
+
+## H) JSON Stub (aggregate fallback)
+
+This version works once `NdM+K` is supported, without any other schema changes. Darts are implicitly focused on the current target.
+
+```json
+{
+  "id": "wiz.magic_missile.srd521",
+  "name": "Magic Missile",
+  "source": "SRD 5.2.1",
+  "school": "evocation",
+  "level": 1,
+  "classes": ["wizard", "sorcerer"],
+  "tags": ["auto-hit", "force"],
+
+  "cast_time_s": 1.0,
+  "gcd_s": 1.0,
+  "cooldown_s": 0.0,
+  "resource_cost": null,
+  "can_move_while_casting": false,
+
+  "targeting": "unit",
+  "requires_line_of_sight": true,
+  "range_ft": 120,
+  "minimum_range_ft": 0,
+  "firing_arc_deg": 180,
+
+  "attack": null,
+  "save": null,
+  "damage": { "type": "force", "add_spell_mod_to_damage": false, "dice_by_level_band": { "1-20": "3d4+3" } },
+  "projectile": null
+}
+```
+
+—
+
+Rationale cross‑refs
+- See `docs/fire_bolt.md` for the baseline spec structure mirrored here.
+- Current sim code that informs this plan: `crates/sim_core/src/sim/systems/attack_roll.rs` (auto‑hit path when `attack` is `None`), `crates/sim_core/src/sim/systems/damage.rs` (pending damage resolution and concentration checks), and `tests/sim_systems.rs` (Fire Bolt, Bless, Shield interactions).
+


### PR DESCRIPTION
Summary
- Keep scene visible after death; camera anchors to last player position.
- Show centered death overlay: 'You died.' + 'Press R to respawn'.
- Remove click-based respawn (DPI hit issues), use keyboard R or Enter.
- Fix text spacing (spaces advance via font metrics), so 'You died.' renders correctly.

Details
- UI: add Hud::death_overlay() with helper text; no interactive button.
- Input: Keyboard R/Enter triggers respawn when dead; RMB orbit unchanged.
- Renderer: respawn() rebuilds scene/server, resets player/camera/HP, clears FX.

Build & Lint
- cargo clippy -- -D warnings: clean
- cargo test: passing

Notes
- Screenshots: see attached in the issue / can capture locally.
- No perf-impacting changes to render pipelines.

Requested review: UX/HUD + Gameplay owners.