### PR TITLE
decouple updates via SceneInputs + golden packs (0929 audit phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1603,15 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 name = "client_core"
 version = "0.1.0"
 dependencies = [
+ "glam 0.30.8",
+]
+
+[[package]]
+name = "client_runtime"
+version = "0.1.0"
+dependencies = [
+ "client_core",
+ "collision_static",
  "glam 0.30.8",
 ]
 
@@ -1840,6 +1858,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1914,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cursor-icon"
@@ -1998,6 +2035,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -2478,6 +2525,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -4817,6 +4874,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "client_core",
+ "client_runtime",
  "collision_static",
  "data_runtime",
  "ecs_core",
@@ -4930,6 +4988,7 @@ dependencies = [
  "render_wgpu",
  "serde_json",
  "server_core",
+ "sha2",
  "sim_core",
 ]
 
@@ -5126,6 +5185,17 @@ name = "server_core"
 version = "0.1.0"
 dependencies = [
  "glam 0.30.8",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -5791,6 +5861,12 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typewit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
     "crates/platform_winit", # winit platform loop
     "crates/ux_hud"          # HUD logic
     ,"crates/collision_static"
-]
+, "crates/client_runtime"]
 resolver = "2"
 
 [features]
@@ -47,3 +47,4 @@ draco_decoder = { path = "vendor/draco_decoder-0.0.10" }
 data_runtime = { path = "crates/data_runtime" }
 glam = "0.30.8"
 serde_json = "1.0.145"
+sha2 = "0.10.9"

--- a/crates/client_runtime/Cargo.toml
+++ b/crates/client_runtime/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "client_runtime"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+glam = "0.30"
+client_core = { path = "../client_core", version = "0.1.0" }
+collision_static = { path = "../collision_static", version = "0.1.0" }

--- a/crates/client_runtime/src/lib.rs
+++ b/crates/client_runtime/src/lib.rs
@@ -1,0 +1,38 @@
+//! client_runtime: thin client-side scene inputs and updates.
+//!
+//! This crate decouples controller + collision updates from the renderer.
+//! The renderer consumes `SceneInputs` to update the player transform and
+//! camera, without owning input semantics or collision policy.
+
+use client_core::controller::PlayerController;
+use client_core::input::InputState;
+use collision_static::{Aabb, Capsule, StaticIndex};
+use glam::Vec3;
+
+#[derive(Debug, Clone)]
+pub struct SceneInputs {
+    controller: PlayerController,
+    input: InputState,
+}
+
+impl SceneInputs {
+    pub fn new(initial_pos: Vec3) -> Self {
+        Self { controller: PlayerController::new(initial_pos), input: InputState::default() }
+    }
+    pub fn apply_input(&mut self, input: &InputState) { self.input = *input; }
+    pub fn pos(&self) -> Vec3 { self.controller.pos }
+    pub fn yaw(&self) -> f32 { self.controller.yaw }
+
+    /// Advance the client controller and resolve against static colliders (capsule slide).
+    /// The Y component is left untouched; caller may project to terrain height separately.
+    pub fn update(&mut self, dt: f32, cam_forward: Vec3, static_index: Option<&StaticIndex>) {
+        self.controller.update(&self.input, dt, cam_forward);
+        if let Some(idx) = static_index {
+            let cap = Capsule { p0: Vec3::new(self.controller.pos.x, self.controller.pos.y + 0.4, self.controller.pos.z), p1: Vec3::new(self.controller.pos.x, self.controller.pos.y + 1.8, self.controller.pos.z), radius: 0.4 };
+            let aabb = Aabb { min: Vec3::new(cap.p0.x.min(cap.p1.x) - cap.radius, cap.p0.y.min(cap.p1.y) - cap.radius, cap.p0.z.min(cap.p1.z) - cap.radius), max: Vec3::new(cap.p0.x.max(cap.p1.x) + cap.radius, cap.p0.y.max(cap.p1.y) + cap.radius, cap.p0.z.max(cap.p1.z) + cap.radius) };
+            let _ = aabb;
+            let resolved = collision_static::resolve_slide(self.controller.pos, self.controller.pos, &cap, idx, 0.25, 4);
+            self.controller.pos = resolved;
+        }
+    }
+}

--- a/crates/render_wgpu/Cargo.toml
+++ b/crates/render_wgpu/Cargo.toml
@@ -25,3 +25,4 @@ serde_json = "1.0.145"
 gltf = "1.4.1"
 pollster = "0.4.0"
 collision_static = { version = "0.1.0", path = "../collision_static" }
+client_runtime = { version = "0.1.0", path = "../client_runtime" }

--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -81,6 +81,8 @@ pub struct Renderer {
     max_dim: u32,
     // Consolidated attachments group for depth + offscreen targets
     attachments: Attachments,
+    // Externalized client updates (controls + collision)
+    scene_inputs: client_runtime::SceneInputs,
 
     // Lighting M1: G-Buffer + Hi-Z scaffolding
     gbuffer: Option<gbuffer::GBuffer>,
@@ -1517,7 +1519,8 @@ impl Renderer {
 
             // Player/camera
             pc_index: scene_build.pc_index,
-            player: client_core::controller::PlayerController::new(pc_initial_pos),
+    player: client_core::controller::PlayerController::new(pc_initial_pos),
+        scene_inputs: client_runtime::SceneInputs::new(pc_initial_pos),
             input: Default::default(),
             cam_follow: camera_sys::FollowState {
                 current_pos: glam::vec3(0.0, 5.0, -10.0),

--- a/crates/render_wgpu/src/gfx/renderer/init.rs
+++ b/crates/render_wgpu/src/gfx/renderer/init.rs
@@ -629,6 +629,7 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
         hud_model: Default::default(),
         pc_index: scene_build.pc_index,
         player: client_core::controller::PlayerController::new(pc_initial_pos),
+        scene_inputs: client_runtime::SceneInputs::new(pc_initial_pos),
         input: Default::default(),
         cam_follow: camera_sys::FollowState { current_pos: glam::vec3(0.0, 5.0, -10.0), current_look: scene_build.cam_target },
         pc_cast_queued: false,

--- a/crates/render_wgpu/src/gfx/renderer/render.rs
+++ b/crates/render_wgpu/src/gfx/renderer/render.rs
@@ -29,8 +29,15 @@ pub fn render_impl(r: &mut crate::gfx::Renderer) -> Result<(), SurfaceError> {
         }
     }
 
-    // Update player transform from input (WASD) then camera follow
-    r.update_player_and_camera(dt, aspect);
+    // Update player transform (controls + collision) via external scene inputs
+    {
+        let cam_fwd = r.cam_follow.current_look - r.cam_follow.current_pos;
+        r.scene_inputs.apply_input(&r.input);
+        r.scene_inputs.update(dt, cam_fwd, r.static_index.as_ref());
+        r.player.pos = r.scene_inputs.pos();
+        r.player.yaw = r.scene_inputs.yaw();
+        r.apply_pc_transform();
+    }
     // Simple AI: rotate non-PC wizards to face nearest alive zombie so firebolts aim correctly
     r.update_wizard_ai(dt);
     // Compute local orbit offsets (relative to PC orientation)

--- a/tests/golden_packs.rs
+++ b/tests/golden_packs.rs
@@ -1,0 +1,61 @@
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn golden_spellpack_matches_builder() {
+    // Build pack bytes in-memory using the same format as xtask
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let spells_dir = root.join("data/spells");
+    let mut entries: Vec<(String, serde_json::Value)> = Vec::new();
+    for entry in fs::read_dir(spells_dir).expect("spells dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") { continue; }
+        let name = path.file_stem().unwrap().to_string_lossy().to_string();
+        // Validate it parses as a spec via data_runtime
+        let rel = format!("spells/{}", path.file_name().unwrap().to_string_lossy());
+        let _spec = data_runtime::loader::load_spell_spec(&rel).expect("spell spec");
+        let txt = fs::read_to_string(&path).expect("read spell json");
+        let val: serde_json::Value = serde_json::from_str(&txt).expect("parse json");
+        entries.push((name, val));
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut buf: Vec<u8> = Vec::new();
+    buf.extend_from_slice(b"SPELLPK\0");
+    buf.extend_from_slice(&1u32.to_le_bytes());
+    buf.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+    for (name, json) in &entries {
+        let name_bytes = name.as_bytes();
+        let json_bytes = serde_json::to_vec(json).expect("serde vec");
+        assert!(name_bytes.len() <= u16::MAX as usize);
+        buf.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+        buf.extend_from_slice(name_bytes);
+        buf.extend_from_slice(&(json_bytes.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&json_bytes);
+    }
+    let pack_path = root.join("packs/spellpack.v1.bin");
+    if pack_path.exists() {
+        let on_disk = fs::read(&pack_path).expect("read packs/spellpack.v1.bin");
+        assert_eq!(buf, on_disk, "spellpack bytes differ from builder");
+    } else {
+        // Not built in this test run (expected when running `cargo test` directly). CI uses xtask to build packs first.
+        eprintln!("golden skipped: {} not found", pack_path.display());
+    }
+}
+
+#[test]
+fn golden_zone_meta_sha256() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let meta = root.join("data/zones/wizard_woods/snapshot.v1/zone_meta.json");
+    if !meta.exists() {
+        eprintln!("golden skipped: {} not found", meta.display());
+        return;
+    }
+    let bytes = fs::read(&meta).expect("read zone_meta.json");
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let got = format!("{:x}", hasher.finalize());
+    let expected = "b3e10f4f21ac69674e40511b8af61a67bf864084749ef27e4ac328856da86350";
+    assert_eq!(got, expected, "zone_meta.json sha256 mismatch");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -48,6 +48,8 @@ fn ci() -> Result<()> {
     cargo(&["clippy", "--all-targets", "--", "-D", "warnings"])?;
     wgsl_validate()?;
     cargo_deny()?;
+    // Build packs so golden tests can read outputs
+    build_packs()?;
     cargo(&["test"])?;
     schema_check()?;
     Ok(())


### PR DESCRIPTION
This PR implements Hour 2 of the 2025‑09‑29 audit plan.

Update Decoupling
- Added new crate `client_runtime` with `SceneInputs` (controller + collision slide).
- Renderer now consumes `SceneInputs` instead of updating controls/collision inline.
  - `gfx::Renderer` gains a `scene_inputs` field.
  - `render()` calls `scene_inputs.apply_input()` + `scene_inputs.update()` and then updates the PC transform.

Golden Packs
- `xtask ci` now builds packs before tests (`spellpack.v1.bin` and zone snapshot).
- Added tests in `tests/golden_packs.rs`:
  - `golden_spellpack_matches_builder` builds pack bytes in-memory and compares with `packs/spellpack.v1.bin` (skips locally if not present).
  - `golden_zone_meta_sha256` asserts a stable SHA256 for `data/zones/wizard_woods/snapshot.v1/zone_meta.json` (skips if snapshot is absent).

Developer Experience
- `xtask ci` warns if git hooks aren’t configured.
- Pre‑push hook (documented in `AGENTS.md`) runs the full `xtask ci` to catch CI failures locally.

Notes
- This is an incremental decoupling: controller+collision moved out; further extraction (AI, FX scheduling, palettes) can follow.
- Tests skip gracefully when run without packs/snapshots (e.g., `cargo test` locally); CI runs `xtask ci` which builds them first.

CI Entry
- Run: `cargo xtask ci` (fmt + clippy −D warnings + WGSL validation + cargo‑deny if available + build packs + tests + schemas).
