### PR TITLE
SpecDb + typed SimEvent (0929 audit phase 3)

### DIFF
--- a/crates/data_runtime/src/lib.rs
+++ b/crates/data_runtime/src/lib.rs
@@ -11,3 +11,4 @@ pub mod monster;
 pub mod scenario;
 pub mod spell;
 pub mod zone;
+pub mod specdb;

--- a/crates/data_runtime/src/specdb.rs
+++ b/crates/data_runtime/src/specdb.rs
@@ -1,0 +1,59 @@
+//! SpecDb: canonical facade for content specs (spells/classes/monsters).
+//!
+//! Provides in-memory indexes and simple normalization so callers don't need
+//! to guess file names or embed heuristics.
+
+use crate::{loader, spell::SpellSpec};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // Prefer workspace root (two levels up) if it contains data/
+    let ws = here.join("..").join("..");
+    if ws.join("data").is_dir() { ws } else { here }
+}
+
+#[derive(Default)]
+pub struct SpecDb {
+    spells: HashMap<String, SpellSpec>,
+}
+
+impl SpecDb {
+    pub fn load_default() -> Self {
+        let mut db = SpecDb::default();
+        let root = workspace_root();
+        let dir = root.join("data/spells");
+        if dir.is_dir() {
+            for entry in std::fs::read_dir(&dir).unwrap_or_else(|_| std::fs::ReadDir::from(std::fs::read_dir(".").unwrap())) {
+                if let Ok(ent) = entry {
+                    let path = ent.path();
+                    if path.extension().and_then(|s| s.to_str()) != Some("json") { continue; }
+                    let rel = format!("spells/{}", path.file_name().unwrap().to_string_lossy());
+                    if let Ok(spec) = loader::load_spell_spec(&rel) {
+                        Self::index_spell(&mut db.spells, spec);
+                    }
+                }
+            }
+        }
+        db
+    }
+
+    fn index_spell(map: &mut HashMap<String, SpellSpec>, spec: SpellSpec) {
+        let canon = spec.id.clone();
+        let name_key = spec.name.to_ascii_lowercase().replace(' ', "_");
+        let last = canon.rsplit('.').next().unwrap_or(&canon).to_string();
+        map.insert(canon, spec.clone());
+        map.insert(last, spec.clone());
+        map.insert(name_key, spec);
+    }
+
+    pub fn get_spell(&self, id: &str) -> Option<&SpellSpec> {
+        if let Some(s) = self.spells.get(id) { return Some(s); }
+        let last = id.rsplit('.').next().unwrap_or(id);
+        if let Some(s) = self.spells.get(last) { return Some(s); }
+        let name_key = id.to_ascii_lowercase().replace(' ', "_");
+        self.spells.get(&name_key)
+    }
+}
+

--- a/crates/render_wgpu/src/gfx/renderer/init.rs
+++ b/crates/render_wgpu/src/gfx/renderer/init.rs
@@ -497,6 +497,14 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
     // Determine asset forward offset from the zombie root node (if present).
     let zombie_forward_offset = zombies::forward_offset(&zombie_cpu);
 
+    // Ability timings from SpecDb (canonical)
+    let specdb = data_runtime::specdb::SpecDb::load_default();
+    let (pc_cast_time, firebolt_cd_dur, gcd_duration) = if let Some(fb) = specdb.get_spell("wiz.fire_bolt.srd521") {
+        (fb.cast_time_s, fb.cooldown_s, fb.gcd_s)
+    } else {
+        (1.5, 0.5, 1.5)
+    };
+
     Ok(crate::gfx::Renderer {
         surface,
         device,
@@ -635,12 +643,12 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
         pc_cast_queued: false,
         pc_cast_kind: Some(super::super::PcCast::FireBolt),
         pc_anim_start: None,
-        pc_cast_time: 1.5,
+        pc_cast_time,
         pc_cast_fired: false,
         firebolt_cd_until: 0.0,
-        firebolt_cd_dur: 0.5,
+        firebolt_cd_dur,
         gcd_until: 0.0,
-        gcd_duration: 1.5,
+        gcd_duration,
         cam_orbit_yaw: 0.0,
         cam_orbit_pitch: 0.2,
         cam_distance: 8.5,

--- a/crates/render_wgpu/src/gfx/renderer/update.rs
+++ b/crates/render_wgpu/src/gfx/renderer/update.rs
@@ -105,8 +105,7 @@ impl Renderer {
                             super::super::PcCast::FireBolt => {
                                 let fb_col = [2.6, 0.7, 0.18];
                                 self.spawn_firebolt(spawn, dir_w, t, Some(self.pc_index), false, fb_col);
-                                self.firebolt_cd_dur = 0.5;
-                                self.firebolt_cd_until = self.last_time + self.firebolt_cd_dur;
+                                self.firebolt_cd_until = self.last_time + self.firebolt_cd_dur.max(0.0);
                             }
                             super::super::PcCast::MagicMissile => {
                                 self.spawn_magic_missile(spawn, dir_w, t);

--- a/crates/sim_core/src/sim/events.rs
+++ b/crates/sim_core/src/sim/events.rs
@@ -1,1 +1,15 @@
-pub struct SimEvent;
+#[derive(Debug, Clone)]
+pub enum SimEvent {
+    CastStarted { actor: String, ability: String, cast_ms: u32, gcd_ms: u32 },
+    CastCompleted { actor: String, ability: String },
+    AllyImmunity { actor: String, target: String, ability: String },
+    ShieldReaction { target: String, new_ac: i32 },
+    AttackResolved { actor: String, ability: String, roll: i32, bonus: i32, total: i32, target_ac: i32, hit: bool },
+    SaveResolved { caster: String, target: String, ability: String, save: String, total: i32, dc: i32, success: bool },
+    ConditionApplied { target: String, condition: String, duration_ms: u32 },
+    TempHpAbsorb { target: String, absorbed: i32, thp_now: i32 },
+    DamageApplied { caster: String, target: String, ability: String, amount: i32, hp_before: i32, hp_after: i32 },
+    ConcentrationCheck { target: String, roll: i32, dc: i32, keep: bool },
+    ConcentrationBroken { target: String, ability: String },
+    BlessApplied { caster: String, duration_ms: u32 },
+}

--- a/crates/sim_core/src/sim/runner.rs
+++ b/crates/sim_core/src/sim/runner.rs
@@ -107,12 +107,9 @@ pub fn run_scenario(scn: &Scenario, result_only: bool) {
     }
 
     // Print summary
-    for log in &state.logs {
-        println!("[sim] {}", log);
-    }
     if !result_only {
-        for log in &state.logs {
-            println!("[sim] {}", log);
+        for ev in &state.events {
+            println!("[sim] {:?}", ev);
         }
     }
     for a in &state.actors {

--- a/crates/sim_core/src/sim/systems/attack_roll.rs
+++ b/crates/sim_core/src/sim/systems/attack_roll.rs
@@ -1,6 +1,7 @@
 //! Resolve attack rolls for newly completed casts.
 
 use crate::rules::attack::Advantage;
+use crate::sim::events::SimEvent;
 use crate::sim::state::SimState;
 
 pub fn run(state: &mut SimState) {
@@ -26,10 +27,7 @@ pub fn run(state: &mut SimState) {
                 if state.are_allies(actor_idx, tgt_idx) {
                     let actor_id = state.actors[actor_idx].id.clone();
                     let tgt_id = state.actors[tgt_idx].id.clone();
-                    state.log(format!(
-                        "ally_immunity actor={} -> tgt={} ability={} (skipped)",
-                        actor_id, tgt_id, ability_id
-                    ));
+                    state.events.push(SimEvent::AllyImmunity { actor: actor_id, target: tgt_id, ability: ability_id.clone() });
                     continue;
                 }
                 if !state.actor_alive(tgt_idx) {
@@ -58,23 +56,11 @@ pub fn run(state: &mut SimState) {
                 state.actors[tgt_idx].ac_temp_bonus += 5;
                 state.actors[tgt_idx].reaction_ready = false;
                 target_ac += 5;
-                state.log(format!(
-                    "shield_reaction tgt={} +5 AC -> {}",
-                    state.actors[tgt_idx].id, target_ac
-                ));
+                state.events.push(SimEvent::ShieldReaction { target: state.actors[tgt_idx].id.clone(), new_ac: target_ac });
             }
             let hit = total >= target_ac;
             let actor_id = state.actors[actor_idx].id.clone();
-            state.log(format!(
-                "attack_resolved actor={} ability={} d20={} + {} = {} vs AC{} => {}",
-                actor_id,
-                ability_id,
-                roll,
-                bonus,
-                total,
-                target_ac,
-                if hit { "HIT" } else { "MISS" }
-            ));
+            state.events.push(SimEvent::AttackResolved { actor: actor_id, ability: ability_id.clone(), roll, bonus, total, target_ac, hit });
             if hit {
                 state
                     .pending_damage

--- a/crates/sim_core/src/sim/systems/cast_begin.rs
+++ b/crates/sim_core/src/sim/systems/cast_begin.rs
@@ -3,6 +3,7 @@
 //! have a known ability. Cast times and GCD are pulled from loaded SpellSpecs.
 
 use crate::combat::fsm::ActionState;
+use crate::sim::events::SimEvent;
 use crate::sim::state::{ActorSim, SimState};
 use data_runtime::ids::Id;
 
@@ -76,10 +77,7 @@ pub fn run(state: &mut SimState) {
             a.id.clone()
         };
         if started {
-            state.log(format!(
-                "cast_started actor={} ability={} cast_ms={} gcd_ms={}",
-                actor_id, first, cast_ms, gcd_ms
-            ));
+            state.events.push(SimEvent::CastStarted { actor: actor_id, ability: first.clone(), cast_ms, gcd_ms });
         }
     }
 }

--- a/crates/sim_core/src/sim/systems/conditions.rs
+++ b/crates/sim_core/src/sim/systems/conditions.rs
@@ -1,16 +1,14 @@
 //! Apply pending statuses and tick durations.
 
 use crate::sim::state::SimState;
+use crate::sim::events::SimEvent;
 
 pub fn run(state: &mut SimState) {
     // Apply pending
     let add = std::mem::take(&mut state.pending_status);
     for (idx, cond, dur) in add {
         state.actors[idx].statuses.push((cond, dur));
-        state.log(format!(
-            "condition_applied tgt={} cond={:?} dur_ms={}",
-            state.actors[idx].id, cond, dur
-        ));
+        state.events.push(SimEvent::ConditionApplied { target: state.actors[idx].id.clone(), condition: format!("{:?}", cond), duration_ms: dur });
     }
     // Tick durations and drop expired
     for a in &mut state.actors {

--- a/crates/sim_core/src/sim/systems/saving_throw.rs
+++ b/crates/sim_core/src/sim/systems/saving_throw.rs
@@ -3,6 +3,7 @@
 use crate::combat::conditions::Condition;
 use crate::rules::saves::SaveKind;
 use crate::sim::state::SimState;
+use crate::sim::events::SimEvent;
 
 fn parse_save_kind(s: &str) -> SaveKind {
     match s.to_ascii_lowercase().as_str() {
@@ -56,16 +57,7 @@ pub fn run(state: &mut SimState) {
         let caster_id = state.actors[actor_idx].id.clone();
         let tgt_id = state.actors[tgt_idx].id.clone();
         let ok = total >= dc;
-        state.log(format!(
-            "save_resolved src={} tgt={} ability={} save={} total={} vs DC{} => {}",
-            caster_id,
-            tgt_id,
-            ability_id,
-            save_kind_s,
-            total,
-            dc,
-            if ok { "SUCCEED" } else { "FAIL" }
-        ));
+        state.events.push(SimEvent::SaveResolved { caster: caster_id.clone(), target: tgt_id.clone(), ability: ability_id.clone(), save: save_kind_s.clone(), total, dc, success: ok });
         if !ok
             && let Some(of) = on_fail
             && let Some(name) = of.apply_condition.as_deref()


### PR DESCRIPTION
Implements Hour 3 of the audit plan: SpecDb & Event Log.

SpecDb (data_runtime)
- Added `data_runtime::specdb::SpecDb` with in‑memory indexes for spells.
- Provides normalization (by full id, last segment, name key) and `load_default()` scanning `data/spells`.
- Sim now uses `SpecDb` for spell lookups; removed ad‑hoc file/substring heuristics from `SimState::load_spell`.

Typed SimEvent (sim_core)
- Introduced `SimEvent` enum (CastStarted, CastCompleted, AllyImmunity, ShieldReaction, AttackResolved, SaveResolved, ConditionApplied, TempHpAbsorb, DamageApplied, ConcentrationCheck, ConcentrationBroken, BlessApplied).
- `SimState` now stores `events: Vec<SimEvent>` and a `spec_db: SpecDb`.
- All systems switched from string logs to typed events; tests updated accordingly.

Renderer cooldown source of truth
- Renderer derives Fire Bolt timings (cast, gcd, cooldown) from `SpecDb` and no longer hardcodes values.
- Removed ad‑hoc cooldown write from update path; respects the SpecDb duration.

Golden/CI tie‑ins
- Existing golden tests remain; xtask CI continues to build packs before tests.

Notes
- This is the minimal, typed event migration to keep tests green and improve assertions.
- Future work (separate PR): expand SpecDb to classes/monsters, move more client timing/state to a shared source, and add CPU hashing tests.
