### PR TITLE
gfx: purple Magic Missile lighting

### DIFF
--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -1819,7 +1819,9 @@ impl Renderer {
                     break;
                 }
                 raw.pos_radius[n] = [p.pos.x, p.pos.y, p.pos.z, maxr];
-                raw.color[n] = [3.0, 1.2, 0.4, 0.0];
+                // Match dynamic light tint to projectile color (e.g. purple for Magic Missile)
+                let s = 1.2f32;
+                raw.color[n] = [p.color[0] * s, p.color[1] * s, p.color[2] * s, 0.0];
                 n += 1;
             }
             raw.count = n as u32;

--- a/crates/render_wgpu/src/gfx/renderer/render.rs
+++ b/crates/render_wgpu/src/gfx/renderer/render.rs
@@ -210,7 +210,10 @@ pub fn render_impl(r: &mut crate::gfx::Renderer) -> Result<(), SurfaceError> {
                 break;
             }
             raw.pos_radius[n] = [p.pos.x, p.pos.y, p.pos.z, maxr];
-            raw.color[n] = [3.0, 1.2, 0.4, 0.0];
+            // Tint dynamic light by projectile color so different spells light correctly
+            // Fire Bolt remains warm; Magic Missile emits a purple light.
+            let s = 1.2f32; // slight boost to keep brightness similar to previous orange
+            raw.color[n] = [p.color[0] * s, p.color[1] * s, p.color[2] * s, 0.0];
             n += 1;
         }
         raw.count = n as u32;


### PR DESCRIPTION
- Lights emitted by projectiles now use each projectile's color, replacing the prior hard-coded orange.
- Fire Bolt remains warm; Magic Missile now casts a purple light as it passes mobs.
- Slight brightness boost (1.2x) maintains previous intensity.

Testing
- Ran 'cargo xtask ci' (fmt, clippy -D warnings, WGSL validation, tests, schema): all green.

Perf
- No expected GPU cost change; only light UBO packing changed. < 0.5 ms.

Notes
- No data/schema changes. No gameplay rules changes.
- Renderer-only change in dynamic light color mapping.