### PR TITLE
gfx: add Death Knight model (zombie-guy.glb), 5x scale

### DIFF
--- a/crates/render_wgpu/src/gfx/deathknight.rs
+++ b/crates/render_wgpu/src/gfx/deathknight.rs
@@ -1,0 +1,110 @@
+//! Death Knight assets and instance building.
+//! Loads a skinned GLB (zombie-guy.glb), builds vertex/index buffers,
+//! and constructs a single oversized instance placed in-scene.
+//!
+//! Scope
+//! - Keep this minimal and data‑parallel to the existing `zombies` module so
+//!   we can later generalize both into a common skinned group helper.
+//! - This module intentionally mirrors function names used by `zombies.rs` so
+//!   renderer init stays straightforward.
+
+use anyhow::{Context, Result};
+use wgpu::util::DeviceExt;
+
+use crate::gfx::types::{InstanceSkin, VertexSkinned};
+use ra_assets::skinning::load_gltf_skinned;
+
+pub struct DeathKnightAssets {
+    pub cpu: ra_assets::types::SkinnedMeshCPU,
+    pub vb: wgpu::Buffer,
+    pub ib: wgpu::Buffer,
+    pub index_count: u32,
+}
+
+pub fn load_assets(device: &wgpu::Device) -> Result<DeathKnightAssets> {
+    let model_path = "assets/models/zombie-guy.glb";
+    let cpu = load_gltf_skinned(&asset_path(model_path))
+        .with_context(|| format!("load skinned {}", model_path))?;
+
+    let verts: Vec<VertexSkinned> = cpu
+        .vertices
+        .iter()
+        .map(|v| VertexSkinned {
+            pos: v.pos,
+            nrm: v.nrm,
+            joints: v.joints,
+            weights: v.weights,
+            uv: v.uv,
+        })
+        .collect();
+    let vb = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("deathknight-vb"),
+        contents: bytemuck::cast_slice(&verts),
+        usage: wgpu::BufferUsages::VERTEX,
+    });
+    let ib = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("deathknight-ib"),
+        contents: bytemuck::cast_slice(&cpu.indices),
+        usage: wgpu::BufferUsages::INDEX,
+    });
+    let index_count = cpu.indices.len() as u32;
+    Ok(DeathKnightAssets {
+        cpu,
+        vb,
+        ib,
+        index_count,
+    })
+}
+
+/// Build a single instance for the Death Knight.
+/// Placement: in front of the PC/wizard circle along +Z at a comfortable distance.
+pub fn build_instances(
+    device: &wgpu::Device,
+    terrain_cpu: &crate::gfx::terrain::TerrainCPU,
+    joints: u32,
+) -> (wgpu::Buffer, Vec<InstanceSkin>, Vec<glam::Mat4>, u32) {
+    let radius = 18.0f32; // outside the wizard ring (~7.5)
+    // Sample terrain height under desired spot
+    let (h, _n) = crate::gfx::terrain::height_at(terrain_cpu, 0.0, radius);
+    let pos = glam::vec3(0.0, h, radius);
+    let scale = glam::Vec3::splat(5.0); // 5x wizard size
+    let m = glam::Mat4::from_scale_rotation_translation(scale, glam::Quat::IDENTITY, pos);
+    let mut instances_cpu: Vec<InstanceSkin> = Vec::new();
+    let mut models: Vec<glam::Mat4> = Vec::new();
+    models.push(m);
+    instances_cpu.push(InstanceSkin {
+        model: m.to_cols_array_2d(),
+        color: [1.0, 1.0, 1.0],
+        selected: 0.0,
+        palette_base: 0 * joints, // single instance
+        _pad_inst: [0; 3],
+    });
+    let instances = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("deathknight-instances"),
+        contents: bytemuck::cast_slice(&instances_cpu),
+        usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+    });
+    (instances, instances_cpu, models, 1)
+}
+
+/// Determine the authored forward offset from the model's root node (if present).
+pub fn forward_offset(cpu: &ra_assets::types::SkinnedMeshCPU) -> f32 {
+    if let Some(root_ix) = cpu.root_node {
+        let r = cpu
+            .base_r
+            .get(root_ix)
+            .copied()
+            .unwrap_or(glam::Quat::IDENTITY);
+        let f = r * glam::Vec3::Z; // authoring forward
+        f32::atan2(f.x, f.z) + std::f32::consts::PI
+    } else {
+        0.0
+    }
+}
+
+fn asset_path(rel: &str) -> std::path::PathBuf {
+    let here = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let ws = here.join("../../").join(rel);
+    if ws.exists() { ws } else { here.join(rel) }
+}
+

--- a/crates/render_wgpu/src/gfx/draw.rs
+++ b/crates/render_wgpu/src/gfx/draw.rs
@@ -42,4 +42,19 @@ impl Renderer {
         rpass.set_index_buffer(self.zombie_ib.slice(..), IndexFormat::Uint16);
         rpass.draw_indexed(0..self.zombie_index_count, 0, 0..self.zombie_count);
     }
+
+    pub(crate) fn draw_deathknight(&self, rpass: &mut wgpu::RenderPass<'_>) {
+        if self.dk_count == 0 {
+            return;
+        }
+        rpass.set_pipeline(&self.wizard_pipeline);
+        rpass.set_bind_group(0, &self.globals_bg, &[]);
+        rpass.set_bind_group(1, &self.shard_model_bg, &[]);
+        rpass.set_bind_group(2, &self.dk_palettes_bg, &[]);
+        rpass.set_bind_group(3, &self.dk_mat_bg, &[]);
+        rpass.set_vertex_buffer(0, self.dk_vb.slice(..));
+        rpass.set_vertex_buffer(1, self.dk_instances.slice(..));
+        rpass.set_index_buffer(self.dk_ib.slice(..), IndexFormat::Uint16);
+        rpass.draw_indexed(0..self.dk_index_count, 0, 0..self.dk_count);
+    }
 }

--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -26,6 +26,7 @@ mod types;
 pub use types::Vertex;
 mod anim;
 mod camera_sys;
+mod deathknight;
 mod draw;
 mod foliage;
 pub mod fx;
@@ -39,7 +40,6 @@ pub mod terrain;
 mod ui;
 mod util;
 mod zombies;
-mod deathknight;
 
 use data_runtime::spell::SpellSpec;
 use ra_assets::types::{AnimClip, SkinnedMeshCPU, TrackQuat, TrackVec3};
@@ -200,6 +200,7 @@ pub struct Renderer {
     // Death Knight instances
     dk_instances: wgpu::Buffer,
     dk_count: u32,
+    #[allow(dead_code)]
     dk_instances_cpu: Vec<InstanceSkin>,
     ruins_instances: wgpu::Buffer,
     ruins_count: u32,

--- a/crates/render_wgpu/src/gfx/renderer/init.rs
+++ b/crates/render_wgpu/src/gfx/renderer/init.rs
@@ -679,8 +679,8 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
     let _zombie_sampler = zmat.sampler;
 
     // Death Knight assets (skinned, single instance)
-    let dk_assets = super::super::deathknight::load_assets(&device)
-        .context("load deathknight assets")?;
+    let dk_assets =
+        super::super::deathknight::load_assets(&device).context("load deathknight assets")?;
     let dk_cpu = dk_assets.cpu;
     let dk_vb = dk_assets.vb;
     let dk_ib = dk_assets.ib;

--- a/crates/render_wgpu/src/gfx/renderer/render.rs
+++ b/crates/render_wgpu/src/gfx/renderer/render.rs
@@ -494,11 +494,11 @@ pub fn render_impl(r: &mut crate::gfx::Renderer) -> Result<(), SurfaceError> {
             }
         }
         // Death Knight bar (show full for now; server hook to follow)
-        if r.dk_count > 0 {
-            if let Some(m) = r.dk_models.get(0).copied() {
-                let head = m * glam::Vec4::new(0.0, 2.3, 0.0, 1.0);
-                bar_entries.push((head.truncate(), 1.0));
-            }
+        if r.dk_count > 0
+            && let Some(m) = r.dk_models.first().copied()
+        {
+            let head = m * glam::Vec4::new(0.0, 2.3, 0.0, 1.0);
+            bar_entries.push((head.truncate(), 1.0));
         }
         // Queue bars vertices and draw to the active target
         r.bars.queue_entries(
@@ -581,21 +581,21 @@ pub fn render_impl(r: &mut crate::gfx::Renderer) -> Result<(), SurfaceError> {
             r.nameplates_npc.draw(&mut encoder, labels_target);
         }
         // Death Knight nameplate
-        if r.dk_count > 0 {
-            if let Some(m) = r.dk_models.get(0).copied() {
-                let head = m * glam::Vec4::new(0.0, 2.6, 0.0, 1.0);
-                let pos = vec![head.truncate()];
-                r.nameplates_npc.queue_npc_labels(
-                    &r.device,
-                    &r.queue,
-                    r.config.width,
-                    r.config.height,
-                    view_proj,
-                    &pos,
-                    "Death Knight",
-                );
-                r.nameplates_npc.draw(&mut encoder, labels_target);
-            }
+        if r.dk_count > 0
+            && let Some(m) = r.dk_models.first().copied()
+        {
+            let head = m * glam::Vec4::new(0.0, 2.6, 0.0, 1.0);
+            let pos = vec![head.truncate()];
+            r.nameplates_npc.queue_npc_labels(
+                &r.device,
+                &r.queue,
+                r.config.width,
+                r.config.height,
+                view_proj,
+                &pos,
+                "Death Knight",
+            );
+            r.nameplates_npc.draw(&mut encoder, labels_target);
         }
     }
 

--- a/src/README.md
+++ b/src/README.md
@@ -96,7 +96,9 @@ Gameplay wiring (prototype)
   - scene.rs — Demo scene assembly (spawn world, build instance buffers, camera target). Wizards now spawn over generated terrain.
   - material.rs — Wizard material creation (base color texture + transform uniform).
   - fx.rs — FX resources (instances buffer, model bind group, quad VB) and integration helpers.
-  - draw.rs — Renderer draw methods for wizards and particles.
+  - zombies.rs — Skinned zombie assets/instances (server-driven ring).
+  - deathknight.rs — Skinned Death Knight boss (zombie-guy.glb), single oversized instance.
+  - draw.rs — Renderer draw methods for wizards, zombies, death knight, and particles.
   - ui.rs — On-screen UI overlays (nameplates/text/bars) rendered in screen space, plus a minimal HUD.
 
 ## Build & Dev Loop


### PR DESCRIPTION
- Loads skinned boss model from assets/models/zombie-guy.glb\n- Adds single Death Knight instance at ~+Z 18m, scaled 5x\n- Wires palettes, material, draw call, and overlays (nameplate + health bar stub)\n- Keeps structure parallel to zombies for future generalization\n\nNotes\n- No abilities/AI in this PR (tracked in #63).\n- Next step: data-driven boss kit + server integration.\n