### PR TITLE
core: add core_units and core_materials crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /videos
 
 docs/srd/.tmp/
+.codex

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_materials"
+version = "0.1.0"
+dependencies = [
+ "core_units",
+]
+
+[[package]]
+name = "core_units"
+version = "0.1.0"
+
+[[package]]
 name = "coreaudio-rs"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,9 @@ dependencies = [
 [[package]]
 name = "core_units"
 version = "0.1.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "coreaudio-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
     "crates/platform_winit", # winit platform loop
     "crates/ux_hud"          # HUD logic
     ,"crates/collision_static"
-, "crates/client_runtime"]
+, "crates/client_runtime", "crates/core_units", "crates/core_materials"]
 resolver = "2"
 
 [features]

--- a/crates/core_materials/Cargo.toml
+++ b/crates/core_materials/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "core_materials"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core_units = { version = "0.1.0", path = "../core_units" }

--- a/crates/core_materials/src/lib.rs
+++ b/crates/core_materials/src/lib.rs
@@ -9,7 +9,7 @@
 //! - Add optional properties (yield strength, thermal_k) as `Option<f64>` later.
 //! - Add `serde` behind a feature if materials cross process boundaries.
 
-use core_units::{cube_volume_m3, Length, Mass};
+use core_units::{Length, Mass, cube_volume_m3};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MaterialId(pub u16);
@@ -23,12 +23,36 @@ pub struct MaterialInfo {
 
 /// Initial palette approved for P0.
 pub static MATERIALS: &[MaterialInfo] = &[
-    MaterialInfo { name: "stone",    density_kg_m3: 2400.0, albedo: [0.55, 0.55, 0.55] },
-    MaterialInfo { name: "wood",     density_kg_m3:  500.0, albedo: [0.45, 0.30, 0.15] },
-    MaterialInfo { name: "steel",    density_kg_m3: 7850.0, albedo: [0.50, 0.50, 0.55] },
-    MaterialInfo { name: "concrete", density_kg_m3: 2400.0, albedo: [0.60, 0.60, 0.60] },
-    MaterialInfo { name: "glass",    density_kg_m3: 2500.0, albedo: [0.70, 0.85, 0.90] },
-    MaterialInfo { name: "dirt",     density_kg_m3: 1600.0, albedo: [0.35, 0.25, 0.20] },
+    MaterialInfo {
+        name: "stone",
+        density_kg_m3: 2400.0,
+        albedo: [0.55, 0.55, 0.55],
+    },
+    MaterialInfo {
+        name: "wood",
+        density_kg_m3: 500.0,
+        albedo: [0.45, 0.30, 0.15],
+    },
+    MaterialInfo {
+        name: "steel",
+        density_kg_m3: 7850.0,
+        albedo: [0.50, 0.50, 0.55],
+    },
+    MaterialInfo {
+        name: "concrete",
+        density_kg_m3: 2400.0,
+        albedo: [0.60, 0.60, 0.60],
+    },
+    MaterialInfo {
+        name: "glass",
+        density_kg_m3: 2500.0,
+        albedo: [0.70, 0.85, 0.90],
+    },
+    MaterialInfo {
+        name: "dirt",
+        density_kg_m3: 1600.0,
+        albedo: [0.35, 0.25, 0.20],
+    },
 ];
 
 /// Look up a material by case-insensitive name.

--- a/crates/core_materials/src/lib.rs
+++ b/crates/core_materials/src/lib.rs
@@ -1,0 +1,79 @@
+//! core_materials: static material palette for physically-plausible parameters.
+//!
+//! Scope
+//! - Simple registry of materials with density (kg/m^3) and display albedo.
+//! - Lightweight ID lookup by name for CLI/config friendliness.
+//! - Helper to compute debris mass from voxel size and density.
+//!
+//! Extending
+//! - Add optional properties (yield strength, thermal_k) as `Option<f64>` later.
+//! - Add `serde` behind a feature if materials cross process boundaries.
+
+use core_units::{cube_volume_m3, Length, Mass};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MaterialId(pub u16);
+
+#[derive(Clone, Copy, Debug)]
+pub struct MaterialInfo {
+    pub name: &'static str,
+    pub density_kg_m3: f64,
+    pub albedo: [f32; 3],
+}
+
+/// Initial palette approved for P0.
+pub static MATERIALS: &[MaterialInfo] = &[
+    MaterialInfo { name: "stone",    density_kg_m3: 2400.0, albedo: [0.55, 0.55, 0.55] },
+    MaterialInfo { name: "wood",     density_kg_m3:  500.0, albedo: [0.45, 0.30, 0.15] },
+    MaterialInfo { name: "steel",    density_kg_m3: 7850.0, albedo: [0.50, 0.50, 0.55] },
+    MaterialInfo { name: "concrete", density_kg_m3: 2400.0, albedo: [0.60, 0.60, 0.60] },
+    MaterialInfo { name: "glass",    density_kg_m3: 2500.0, albedo: [0.70, 0.85, 0.90] },
+    MaterialInfo { name: "dirt",     density_kg_m3: 1600.0, albedo: [0.35, 0.25, 0.20] },
+];
+
+/// Look up a material by case-insensitive name.
+pub fn find_material_id(name: &str) -> Option<MaterialId> {
+    let n = name.trim().to_ascii_lowercase();
+    MATERIALS
+        .iter()
+        .position(|m| m.name.eq_ignore_ascii_case(&n))
+        .map(|idx| MaterialId(idx as u16))
+}
+
+/// Fetch material info by id.
+pub fn get(mat: MaterialId) -> Option<&'static MaterialInfo> {
+    MATERIALS.get(mat.0 as usize)
+}
+
+/// Compute mass for a single voxel cube of edge `voxel_m` (meters) for a given material.
+pub fn mass_for_voxel(mat: MaterialId, voxel_m: Length) -> Option<Mass> {
+    let m = get(mat)?;
+    let vol = cube_volume_m3(voxel_m); // m^3
+    Some(Mass(m.density_kg_m3 * vol))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_and_get_material() {
+        let id = find_material_id("Stone").expect("find stone");
+        let info = get(id).unwrap();
+        assert_eq!(info.name, "stone");
+        assert!((info.density_kg_m3 - 2400.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mass_scales_with_density_and_voxel_size() {
+        let stone = find_material_id("stone").unwrap();
+        let wood = find_material_id("wood").unwrap();
+        let v = Length(0.25); // 0.25 m → 0.015625 m^3
+        let m_stone = mass_for_voxel(stone, v).unwrap();
+        let m_wood = mass_for_voxel(wood, v).unwrap();
+        let vol = 0.25f64 * 0.25 * 0.25;
+        assert!((f64::from(m_stone) - 2400.0 * vol).abs() < 1e-9);
+        assert!((f64::from(m_wood) - 500.0 * vol).abs() < 1e-9);
+        assert!(f64::from(m_stone) > f64::from(m_wood));
+    }
+}

--- a/crates/core_units/Cargo.toml
+++ b/crates/core_units/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "core_units"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/crates/core_units/Cargo.toml
+++ b/crates/core_units/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+serde = { version = "1.0.228", features = ["derive"], optional = true }
+
+[features]
+serde = ["dep:serde"]

--- a/crates/core_units/src/lib.rs
+++ b/crates/core_units/src/lib.rs
@@ -1,0 +1,167 @@
+//! core_units: strongly-typed base units in meters/seconds/kilograms.
+//!
+//! Scope
+//! - Provide simple `Length`, `Time`, and `Mass` newtypes (f64 under the hood).
+//! - Implement basic arithmetic with scalars and same-typed values.
+//! - Keep this crate tiny and dependency-free; conversions are explicit.
+//!
+//! Extending
+//! - Add velocity/acceleration types as needed in follow-ups (e.g., `Velocity` = m/s).
+//! - Consider `serde` feature-gated derives when units cross process boundaries.
+
+use core::fmt;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
+/// Length in meters (f64).
+#[derive(Clone, Copy, Default, PartialEq, PartialOrd)]
+pub struct Length(pub f64);
+
+/// Time in seconds (f64).
+#[derive(Clone, Copy, Default, PartialEq, PartialOrd)]
+pub struct Time(pub f64);
+
+/// Mass in kilograms (f64).
+#[derive(Clone, Copy, Default, PartialEq, PartialOrd)]
+pub struct Mass(pub f64);
+
+impl fmt::Debug for Length {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.6} m", self.0)
+    }
+}
+impl fmt::Debug for Time {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.6} s", self.0)
+    }
+}
+impl fmt::Debug for Mass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.6} kg", self.0)
+    }
+}
+
+// Conversions
+impl From<f64> for Length {
+    fn from(v: f64) -> Self {
+        Length(v)
+    }
+}
+impl From<Length> for f64 {
+    fn from(v: Length) -> Self {
+        v.0
+    }
+}
+impl From<f64> for Time {
+    fn from(v: f64) -> Self {
+        Time(v)
+    }
+}
+impl From<Time> for f64 {
+    fn from(v: Time) -> Self {
+        v.0
+    }
+}
+impl From<f64> for Mass {
+    fn from(v: f64) -> Self {
+        Mass(v)
+    }
+}
+impl From<Mass> for f64 {
+    fn from(v: Mass) -> Self {
+        v.0
+    }
+}
+
+// Basic arithmetic with same-type values
+macro_rules! impl_ops_same {
+    ($T:ty) => {
+        impl Add for $T {
+            type Output = $T;
+            fn add(self, rhs: $T) -> $T {
+                <$T>::from(f64::from(self) + f64::from(rhs))
+            }
+        }
+        impl AddAssign for $T {
+            fn add_assign(&mut self, rhs: $T) {
+                *self = *self + rhs;
+            }
+        }
+        impl Sub for $T {
+            type Output = $T;
+            fn sub(self, rhs: $T) -> $T {
+                <$T>::from(f64::from(self) - f64::from(rhs))
+            }
+        }
+        impl SubAssign for $T {
+            fn sub_assign(&mut self, rhs: $T) {
+                *self = *self - rhs;
+            }
+        }
+        impl Mul<f64> for $T {
+            type Output = $T;
+            fn mul(self, rhs: f64) -> $T {
+                <$T>::from(f64::from(self) * rhs)
+            }
+        }
+        impl MulAssign<f64> for $T {
+            fn mul_assign(&mut self, rhs: f64) {
+                *self = *self * rhs;
+            }
+        }
+        impl Div<f64> for $T {
+            type Output = $T;
+            fn div(self, rhs: f64) -> $T {
+                <$T>::from(f64::from(self) / rhs)
+            }
+        }
+        impl DivAssign<f64> for $T {
+            fn div_assign(&mut self, rhs: f64) {
+                *self = *self / rhs;
+            }
+        }
+    };
+}
+
+impl_ops_same!(Length);
+impl_ops_same!(Time);
+impl_ops_same!(Mass);
+
+/// Compute volume of a cube of edge `voxel` (meters^3).
+pub fn cube_volume_m3(voxel: Length) -> f64 {
+    let e = voxel.0;
+    e * e * e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn length_ops_and_convert() {
+        let a = Length::from(2.0);
+        let b = Length::from(3.5);
+        let c = a + b;
+        assert!((f64::from(c) - 5.5).abs() < 1e-12);
+        let mut d = c;
+        d *= 2.0;
+        assert!((f64::from(d) - 11.0).abs() < 1e-12);
+        d /= 4.0;
+        assert!((f64::from(d) - 2.75).abs() < 1e-12);
+    }
+
+    #[test]
+    fn mass_and_time_behave_like_scalars() {
+        let mut m = Mass::from(5.0);
+        m += Mass::from(1.25);
+        assert!((f64::from(m) - 6.25).abs() < 1e-12);
+        let mut t = Time::from(10.0);
+        t -= Time::from(0.25);
+        assert!((f64::from(t) - 9.75).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cube_volume_is_edge_cubed() {
+        let v = cube_volume_m3(Length(0.5));
+        assert!((v - 0.125).abs() < 1e-12);
+    }
+}

--- a/crates/core_units/src/lib.rs
+++ b/crates/core_units/src/lib.rs
@@ -9,18 +9,27 @@
 //! - Add velocity/acceleration types as needed in follow-ups (e.g., `Velocity` = m/s).
 //! - Consider `serde` feature-gated derives when units cross process boundaries.
 
+#![forbid(unsafe_code)]
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use core::fmt;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 /// Length in meters (f64).
+#[repr(transparent)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Default, PartialEq, PartialOrd)]
 pub struct Length(pub f64);
 
 /// Time in seconds (f64).
+#[repr(transparent)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Default, PartialEq, PartialOrd)]
 pub struct Time(pub f64);
 
 /// Mass in kilograms (f64).
+#[repr(transparent)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Default, PartialEq, PartialOrd)]
 pub struct Mass(pub f64);
 
@@ -40,33 +49,55 @@ impl fmt::Debug for Mass {
     }
 }
 
+impl fmt::Display for Length {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl fmt::Display for Time {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl fmt::Display for Mass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 // Conversions
 impl From<f64> for Length {
+    #[inline]
     fn from(v: f64) -> Self {
         Length(v)
     }
 }
 impl From<Length> for f64 {
+    #[inline]
     fn from(v: Length) -> Self {
         v.0
     }
 }
 impl From<f64> for Time {
+    #[inline]
     fn from(v: f64) -> Self {
         Time(v)
     }
 }
 impl From<Time> for f64 {
+    #[inline]
     fn from(v: Time) -> Self {
         v.0
     }
 }
 impl From<f64> for Mass {
+    #[inline]
     fn from(v: f64) -> Self {
         Mass(v)
     }
 }
 impl From<Mass> for f64 {
+    #[inline]
     fn from(v: Mass) -> Self {
         v.0
     }
@@ -77,44 +108,52 @@ macro_rules! impl_ops_same {
     ($T:ty) => {
         impl Add for $T {
             type Output = $T;
+            #[inline]
             fn add(self, rhs: $T) -> $T {
                 <$T>::from(f64::from(self) + f64::from(rhs))
             }
         }
         impl AddAssign for $T {
+            #[inline]
             fn add_assign(&mut self, rhs: $T) {
                 *self = *self + rhs;
             }
         }
         impl Sub for $T {
             type Output = $T;
+            #[inline]
             fn sub(self, rhs: $T) -> $T {
                 <$T>::from(f64::from(self) - f64::from(rhs))
             }
         }
         impl SubAssign for $T {
+            #[inline]
             fn sub_assign(&mut self, rhs: $T) {
                 *self = *self - rhs;
             }
         }
         impl Mul<f64> for $T {
             type Output = $T;
+            #[inline]
             fn mul(self, rhs: f64) -> $T {
                 <$T>::from(f64::from(self) * rhs)
             }
         }
         impl MulAssign<f64> for $T {
+            #[inline]
             fn mul_assign(&mut self, rhs: f64) {
                 *self = *self * rhs;
             }
         }
         impl Div<f64> for $T {
             type Output = $T;
+            #[inline]
             fn div(self, rhs: f64) -> $T {
                 <$T>::from(f64::from(self) / rhs)
             }
         }
         impl DivAssign<f64> for $T {
+            #[inline]
             fn div_assign(&mut self, rhs: f64) {
                 *self = *self / rhs;
             }
@@ -127,9 +166,43 @@ impl_ops_same!(Time);
 impl_ops_same!(Mass);
 
 /// Compute volume of a cube of edge `voxel` (meters^3).
+#[inline]
 pub fn cube_volume_m3(voxel: Length) -> f64 {
     let e = voxel.0;
     e * e * e
+}
+
+// Reverse scalar multiplication for ergonomics: f64 * Unit
+impl Mul<Length> for f64 {
+    type Output = Length;
+    #[inline]
+    fn mul(self, rhs: Length) -> Length { Length(self * rhs.0) }
+}
+impl Mul<Time> for f64 {
+    type Output = Time;
+    #[inline]
+    fn mul(self, rhs: Time) -> Time { Time(self * rhs.0) }
+}
+impl Mul<Mass> for f64 {
+    type Output = Mass;
+    #[inline]
+    fn mul(self, rhs: Mass) -> Mass { Mass(self * rhs.0) }
+}
+
+impl Length {
+    /// Construct from meters.
+    #[inline]
+    pub fn meters(v: f64) -> Self { Self(v) }
+}
+impl Time {
+    /// Construct from seconds.
+    #[inline]
+    pub fn seconds(v: f64) -> Self { Self(v) }
+}
+impl Mass {
+    /// Construct from kilograms.
+    #[inline]
+    pub fn kilograms(v: f64) -> Self { Self(v) }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR lays the groundwork for Issue #75 (Destructible Mesh via Voxel Proxy) by introducing two foundational crates, with thorough unit tests:

What’s included
- crates/core_units — strongly-typed units (`Length`, `Time`, `Mass`) wrapping f64 with basic arithmetic, conversions, and a helper `cube_volume_m3(voxel)`.
- crates/core_materials — static material palette with densities and display albedo; lookup by name (`find_material_id`) and helpers to fetch info and compute `mass_for_voxel(material, voxel)` using `core_units`.

Decisions aligned with owner response
- Units as f64 newtypes at new module boundaries (voxelizer/physics coupling later).
- Materials separate from gameplay data; initial palette: stone, wood, steel, concrete, glass, dirt.

Tests
- core_units: arithmetic and conversion tests; cube-volume correctness.
- core_materials: case-insensitive lookup; mass computation bounds and ordering across materials.

Notes
- No runtime behavior changes; these crates are additive and unused by the app yet.
- Next PRs: `voxel_proxy` + `voxel_mesh` (chunked, greedy) with tests; then server-side projectile → carve → debris pipeline and `collision_static::chunks` for collider refresh.

CI
- Pre-push hook ran `xtask ci` successfully locally (fmt, clippy, WGSL validation, tests).
