### PR TITLE
voxel: scaffold voxel_proxy + voxel_mesh (chunked grid, flood-fill, greedy faces)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,6 +2687,9 @@ name = "glam"
 version = "0.30.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12d847aeb25f41be4c0ec9587d624e9cd631bc007a8fd7ce3f5851e064c6460"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "glob"
@@ -6042,6 +6045,23 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "voxel_mesh"
+version = "0.1.0"
+dependencies = [
+ "glam 0.30.8",
+ "voxel_proxy",
+]
+
+[[package]]
+name = "voxel_proxy"
+version = "0.1.0"
+dependencies = [
+ "core_materials",
+ "core_units",
+ "glam 0.30.8",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
     "crates/platform_winit", # winit platform loop
     "crates/ux_hud"          # HUD logic
     ,"crates/collision_static"
-, "crates/client_runtime", "crates/core_units", "crates/core_materials"]
+, "crates/client_runtime", "crates/core_units", "crates/core_materials", "crates/voxel_proxy", "crates/voxel_mesh"]
 resolver = "2"
 
 [features]

--- a/crates/core_materials/src/lib.rs
+++ b/crates/core_materials/src/lib.rs
@@ -89,12 +89,16 @@ pub fn mass_for_voxel(mat: MaterialId, voxel_m: Length) -> Option<Mass> {
 
 impl From<u16> for MaterialId {
     #[inline]
-    fn from(v: u16) -> Self { MaterialId(v) }
+    fn from(v: u16) -> Self {
+        MaterialId(v)
+    }
 }
 
 impl From<MaterialId> for usize {
     #[inline]
-    fn from(v: MaterialId) -> Self { v.0 as usize }
+    fn from(v: MaterialId) -> Self {
+        v.0 as usize
+    }
 }
 
 #[cfg(test)]

--- a/crates/core_units/src/lib.rs
+++ b/crates/core_units/src/lib.rs
@@ -176,33 +176,45 @@ pub fn cube_volume_m3(voxel: Length) -> f64 {
 impl Mul<Length> for f64 {
     type Output = Length;
     #[inline]
-    fn mul(self, rhs: Length) -> Length { Length(self * rhs.0) }
+    fn mul(self, rhs: Length) -> Length {
+        Length(self * rhs.0)
+    }
 }
 impl Mul<Time> for f64 {
     type Output = Time;
     #[inline]
-    fn mul(self, rhs: Time) -> Time { Time(self * rhs.0) }
+    fn mul(self, rhs: Time) -> Time {
+        Time(self * rhs.0)
+    }
 }
 impl Mul<Mass> for f64 {
     type Output = Mass;
     #[inline]
-    fn mul(self, rhs: Mass) -> Mass { Mass(self * rhs.0) }
+    fn mul(self, rhs: Mass) -> Mass {
+        Mass(self * rhs.0)
+    }
 }
 
 impl Length {
     /// Construct from meters.
     #[inline]
-    pub fn meters(v: f64) -> Self { Self(v) }
+    pub fn meters(v: f64) -> Self {
+        Self(v)
+    }
 }
 impl Time {
     /// Construct from seconds.
     #[inline]
-    pub fn seconds(v: f64) -> Self { Self(v) }
+    pub fn seconds(v: f64) -> Self {
+        Self(v)
+    }
 }
 impl Mass {
     /// Construct from kilograms.
     #[inline]
-    pub fn kilograms(v: f64) -> Self { Self(v) }
+    pub fn kilograms(v: f64) -> Self {
+        Self(v)
+    }
 }
 
 #[cfg(test)]

--- a/crates/voxel_mesh/Cargo.toml
+++ b/crates/voxel_mesh/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "voxel_mesh"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+glam = "0.30.8"
+voxel_proxy = { version = "0.1.0", path = "../voxel_proxy" }

--- a/crates/voxel_mesh/src/lib.rs
+++ b/crates/voxel_mesh/src/lib.rs
@@ -17,13 +17,15 @@ use voxel_proxy::VoxelGrid;
 /// Simple mesh buffers (positions, normals, indices).
 #[derive(Default, Clone)]
 pub struct MeshBuffers {
-    pub positions: Vec<[f32;3]>,
-    pub normals: Vec<[f32;3]>,
+    pub positions: Vec<[f32; 3]>,
+    pub normals: Vec<[f32; 3]>,
     pub indices: Vec<u32>,
 }
 
 impl MeshBuffers {
-    pub fn quad_count(&self) -> usize { self.indices.len() / 6 }
+    pub fn quad_count(&self) -> usize {
+        self.indices.len() / 6
+    }
 }
 
 /// Generate a greedy-meshed surface for the entire grid.
@@ -34,27 +36,37 @@ pub fn greedy_mesh_all(grid: &VoxelGrid) -> MeshBuffers {
     let mut mesh = MeshBuffers::default();
     // Iterate three axes
     for axis in 0..3 {
-        let (w,h,ld, step_w, step_h, step_ld) = plane_dims(axis, d);
+        let (w, h, ld, step_w, step_h, step_ld) = plane_dims(axis, d);
         // For each layer along the axis
         for layer in 0..ld {
             // Build face mask for this slice for positive normal
-            let mut mask = vec![false; (w*h) as usize];
-            let mut mask_neg = vec![false; (w*h) as usize];
-            for j in 0..h { for i in 0..w {
-                let (x,y,z) = to_xyz(axis, i, j, layer);
-                // neighbor in -axis
-                let (xn,yn,zn) = match axis {
-                    0 => (x.saturating_sub(1), y, z),
-                    1 => (x, y.saturating_sub(1), z),
-                    _ => (x, y, z.saturating_sub(1)),
-                };
-                let here = if inside(d,x,y,z) { grid.is_solid(x,y,z) } else { false };
-                let there = if inside(d,xn,yn,zn) { grid.is_solid(xn,yn,zn) } else { false };
-                let m_idx = (i + j*w) as usize;
-                // Solid→empty: positive face; empty→solid: negative face
-                mask[m_idx] = here && !there;
-                mask_neg[m_idx] = !here && there;
-            }}
+            let mut mask = vec![false; (w * h) as usize];
+            let mut mask_neg = vec![false; (w * h) as usize];
+            for j in 0..h {
+                for i in 0..w {
+                    let (x, y, z) = to_xyz(axis, i, j, layer);
+                    // neighbor in -axis
+                    let (xn, yn, zn) = match axis {
+                        0 => (x.saturating_sub(1), y, z),
+                        1 => (x, y.saturating_sub(1), z),
+                        _ => (x, y, z.saturating_sub(1)),
+                    };
+                    let here = if inside(d, x, y, z) {
+                        grid.is_solid(x, y, z)
+                    } else {
+                        false
+                    };
+                    let there = if inside(d, xn, yn, zn) {
+                        grid.is_solid(xn, yn, zn)
+                    } else {
+                        false
+                    };
+                    let m_idx = (i + j * w) as usize;
+                    // Solid→empty: positive face; empty→solid: negative face
+                    mask[m_idx] = here && !there;
+                    mask_neg[m_idx] = !here && there;
+                }
+            }
             // Emit quads for both directions
             greedy_emit(&mut mesh, &mask, axis, layer, w, h, vm, origin, true);
             greedy_emit(&mut mesh, &mask_neg, axis, layer, w, h, vm, origin, false);
@@ -63,16 +75,38 @@ pub fn greedy_mesh_all(grid: &VoxelGrid) -> MeshBuffers {
     mesh
 }
 
-fn plane_dims(axis: u32, d: UVec3) -> (u32,u32,u32, UVec3,UVec3,UVec3) {
-    match axis { // (w,h,ld)
-        0 => (d.y, d.z, d.x, UVec3::new(0,1,0), UVec3::new(0,0,1), UVec3::new(1,0,0)),
-        1 => (d.x, d.z, d.y, UVec3::new(1,0,0), UVec3::new(0,0,1), UVec3::new(0,1,0)),
-        _ => (d.x, d.y, d.z, UVec3::new(1,0,0), UVec3::new(0,1,0), UVec3::new(0,0,1)),
+fn plane_dims(axis: u32, d: UVec3) -> (u32, u32, u32, UVec3, UVec3, UVec3) {
+    match axis {
+        // (w,h,ld)
+        0 => (
+            d.y,
+            d.z,
+            d.x,
+            UVec3::new(0, 1, 0),
+            UVec3::new(0, 0, 1),
+            UVec3::new(1, 0, 0),
+        ),
+        1 => (
+            d.x,
+            d.z,
+            d.y,
+            UVec3::new(1, 0, 0),
+            UVec3::new(0, 0, 1),
+            UVec3::new(0, 1, 0),
+        ),
+        _ => (
+            d.x,
+            d.y,
+            d.z,
+            UVec3::new(1, 0, 0),
+            UVec3::new(0, 1, 0),
+            UVec3::new(0, 0, 1),
+        ),
     }
 }
 
 #[inline]
-fn to_xyz(axis: u32, i: u32, j: u32, l: u32) -> (u32,u32,u32) {
+fn to_xyz(axis: u32, i: u32, j: u32, l: u32) -> (u32, u32, u32) {
     match axis {
         0 => (l, i, j),
         1 => (i, l, j),
@@ -81,7 +115,9 @@ fn to_xyz(axis: u32, i: u32, j: u32, l: u32) -> (u32,u32,u32) {
 }
 
 #[inline]
-fn inside(d: UVec3, x:u32,y:u32,z:u32) -> bool { x<d.x && y<d.y && z<d.z }
+fn inside(d: UVec3, x: u32, y: u32, z: u32) -> bool {
+    x < d.x && y < d.y && z < d.z
+}
 
 fn greedy_emit(
     mesh: &mut MeshBuffers,
@@ -96,36 +132,45 @@ fn greedy_emit(
 ) {
     let mut skipped = vec![false; mask.len()];
     let normal = match (axis, pos_normal) {
-        (0,true) => Vec3::X, (0,false)=> -Vec3::X,
-        (1,true) => Vec3::Y, (1,false)=> -Vec3::Y,
-        (2,true) => Vec3::Z, (2,false)=> -Vec3::Z,
+        (0, true) => Vec3::X,
+        (0, false) => -Vec3::X,
+        (1, true) => Vec3::Y,
+        (1, false) => -Vec3::Y,
+        (2, true) => Vec3::Z,
+        (2, false) => -Vec3::Z,
         _ => Vec3::Z,
     };
     let mut y = 0;
     while y < h {
         let mut x = 0;
         while x < w {
-            let idx = (x + y*w) as usize;
+            let idx = (x + y * w) as usize;
             if mask[idx] && !skipped[idx] {
                 // Find maximal width
                 let mut w_run = 1;
                 while x + w_run < w {
-                    let ii = (x + w_run + y*w) as usize;
-                    if mask[ii] && !skipped[ii] { w_run+=1; } else { break; }
+                    let ii = (x + w_run + y * w) as usize;
+                    if mask[ii] && !skipped[ii] {
+                        w_run += 1;
+                    } else {
+                        break;
+                    }
                 }
                 // Find maximal height
                 let mut h_run = 1;
                 'outer: while y + h_run < h {
-                    for xx in x..(x+w_run) {
-                        let jj = (xx + (y+h_run)*w) as usize;
-                        if !mask[jj] || skipped[jj] { break 'outer; }
+                    for xx in x..(x + w_run) {
+                        let jj = (xx + (y + h_run) * w) as usize;
+                        if !mask[jj] || skipped[jj] {
+                            break 'outer;
+                        }
                     }
                     h_run += 1;
                 }
                 // Mark visited
-                for yy in y..(y+h_run) {
-                    for xx in x..(x+w_run) {
-                        skipped[(xx + yy*w) as usize] = true;
+                for yy in y..(y + h_run) {
+                    for xx in x..(x + w_run) {
+                        skipped[(xx + yy * w) as usize] = true;
                     }
                 }
                 // Emit quad at rectangle [x..x+w_run), [y..y+h_run)
@@ -159,12 +204,12 @@ fn emit_rect(
     };
     // layer is along ax_w
     let base = ax_w * (layer as f32);
-    let p0 = base + ax_u * (x as f32)       + ax_v * (y as f32);
-    let p1 = base + ax_u * ((x+w) as f32)   + ax_v * (y as f32);
-    let p2 = base + ax_u * ((x+w) as f32)   + ax_v * ((y+h) as f32);
-    let p3 = base + ax_u * (x as f32)       + ax_v * ((y+h) as f32);
+    let p0 = base + ax_u * (x as f32) + ax_v * (y as f32);
+    let p1 = base + ax_u * ((x + w) as f32) + ax_v * (y as f32);
+    let p2 = base + ax_u * ((x + w) as f32) + ax_v * ((y + h) as f32);
+    let p3 = base + ax_u * (x as f32) + ax_v * ((y + h) as f32);
     let add = |mesh: &mut MeshBuffers, p: Vec3, n: Vec3| {
-        let wm = origin + p*vm; // place on voxel edge lines in meters
+        let wm = origin + p * vm; // place on voxel edge lines in meters
         mesh.positions.push([wm.x, wm.y, wm.z]);
         mesh.normals.push([n.x, n.y, n.z]);
     };
@@ -174,37 +219,48 @@ fn emit_rect(
     add(mesh, p2, normal);
     add(mesh, p3, normal);
     // Two triangles (i0,i1,i2) and (i0,i2,i3)
-    mesh.indices.extend_from_slice(&[i0, i0+1, i0+2, i0, i0+2, i0+3]);
+    mesh.indices
+        .extend_from_slice(&[i0, i0 + 1, i0 + 2, i0, i0 + 2, i0 + 3]);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use glam::{DVec3, UVec3};
-    use voxel_proxy::{VoxelProxyMeta, GlobalId};
-    use core_units::Length;
     use core_materials::find_material_id;
+    use core_units::Length;
+    use glam::{DVec3, UVec3};
+    use voxel_proxy::{GlobalId, VoxelProxyMeta};
 
     fn mk_full_grid(d: UVec3) -> voxel_proxy::VoxelGrid {
         let meta = VoxelProxyMeta {
-            object_id: GlobalId(1), origin_m: DVec3::ZERO, voxel_m: Length::meters(1.0),
-            dims: d, chunk: UVec3::new(16,16,16), material: find_material_id("stone").unwrap()
+            object_id: GlobalId(1),
+            origin_m: DVec3::ZERO,
+            voxel_m: Length::meters(1.0),
+            dims: d,
+            chunk: UVec3::new(16, 16, 16),
+            material: find_material_id("stone").unwrap(),
         };
         let mut g = voxel_proxy::VoxelGrid::new(meta);
-        for z in 0..d.z { for y in 0..d.y { for x in 0..d.x { g.set(x,y,z,true); }}}
+        for z in 0..d.z {
+            for y in 0..d.y {
+                for x in 0..d.x {
+                    g.set(x, y, z, true);
+                }
+            }
+        }
         g
     }
 
     #[test]
     fn solid_cube_produces_six_quads() {
-        let g = mk_full_grid(UVec3::new(3,3,3));
+        let g = mk_full_grid(UVec3::new(3, 3, 3));
         let m = greedy_mesh_all(&g);
         assert_eq!(m.quad_count(), 6);
     }
 
     #[test]
     fn rod_1x1x8_produces_six_quads() {
-        let mut g = mk_full_grid(UVec3::new(1,1,8));
+        let mut g = mk_full_grid(UVec3::new(1, 1, 8));
         // Already filled by mk_full_grid; just mesh
         let m = greedy_mesh_all(&g);
         assert_eq!(m.quad_count(), 6);

--- a/crates/voxel_mesh/src/lib.rs
+++ b/crates/voxel_mesh/src/lib.rs
@@ -1,0 +1,212 @@
+//! voxel_mesh: greedy meshing for voxel grids (CPU-only).
+//!
+//! Scope
+//! - Convert a `voxel_proxy::VoxelGrid` occupancy to triangle mesh buffers by extracting
+//!   faces on solid→empty boundaries.
+//! - Greedy merge co-planar faces per slice to minimize quad count.
+//!
+//! Extending
+//! - Per-chunk meshing for dirty sets (integrate with queue from voxel_proxy).
+//! - Material IDs per quad for mixed-material P1.
+
+#![forbid(unsafe_code)]
+
+use glam::{UVec3, Vec3};
+use voxel_proxy::VoxelGrid;
+
+/// Simple mesh buffers (positions, normals, indices).
+#[derive(Default, Clone)]
+pub struct MeshBuffers {
+    pub positions: Vec<[f32;3]>,
+    pub normals: Vec<[f32;3]>,
+    pub indices: Vec<u32>,
+}
+
+impl MeshBuffers {
+    pub fn quad_count(&self) -> usize { self.indices.len() / 6 }
+}
+
+/// Generate a greedy-meshed surface for the entire grid.
+pub fn greedy_mesh_all(grid: &VoxelGrid) -> MeshBuffers {
+    let d = grid.meta().dims;
+    let vm = grid.meta().voxel_m.0 as f32;
+    let origin = grid.meta().origin_m.as_vec3();
+    let mut mesh = MeshBuffers::default();
+    // Iterate three axes
+    for axis in 0..3 {
+        let (w,h,ld, step_w, step_h, step_ld) = plane_dims(axis, d);
+        // For each layer along the axis
+        for layer in 0..ld {
+            // Build face mask for this slice for positive normal
+            let mut mask = vec![false; (w*h) as usize];
+            let mut mask_neg = vec![false; (w*h) as usize];
+            for j in 0..h { for i in 0..w {
+                let (x,y,z) = to_xyz(axis, i, j, layer);
+                // neighbor in -axis
+                let (xn,yn,zn) = match axis {
+                    0 => (x.saturating_sub(1), y, z),
+                    1 => (x, y.saturating_sub(1), z),
+                    _ => (x, y, z.saturating_sub(1)),
+                };
+                let here = if inside(d,x,y,z) { grid.is_solid(x,y,z) } else { false };
+                let there = if inside(d,xn,yn,zn) { grid.is_solid(xn,yn,zn) } else { false };
+                let m_idx = (i + j*w) as usize;
+                // Solid→empty: positive face; empty→solid: negative face
+                mask[m_idx] = here && !there;
+                mask_neg[m_idx] = !here && there;
+            }}
+            // Emit quads for both directions
+            greedy_emit(&mut mesh, &mask, axis, layer, w, h, vm, origin, true);
+            greedy_emit(&mut mesh, &mask_neg, axis, layer, w, h, vm, origin, false);
+        }
+    }
+    mesh
+}
+
+fn plane_dims(axis: u32, d: UVec3) -> (u32,u32,u32, UVec3,UVec3,UVec3) {
+    match axis { // (w,h,ld)
+        0 => (d.y, d.z, d.x, UVec3::new(0,1,0), UVec3::new(0,0,1), UVec3::new(1,0,0)),
+        1 => (d.x, d.z, d.y, UVec3::new(1,0,0), UVec3::new(0,0,1), UVec3::new(0,1,0)),
+        _ => (d.x, d.y, d.z, UVec3::new(1,0,0), UVec3::new(0,1,0), UVec3::new(0,0,1)),
+    }
+}
+
+#[inline]
+fn to_xyz(axis: u32, i: u32, j: u32, l: u32) -> (u32,u32,u32) {
+    match axis {
+        0 => (l, i, j),
+        1 => (i, l, j),
+        _ => (i, j, l),
+    }
+}
+
+#[inline]
+fn inside(d: UVec3, x:u32,y:u32,z:u32) -> bool { x<d.x && y<d.y && z<d.z }
+
+fn greedy_emit(
+    mesh: &mut MeshBuffers,
+    mask: &[bool],
+    axis: u32,
+    layer: u32,
+    w: u32,
+    h: u32,
+    vm: f32,
+    origin: Vec3,
+    pos_normal: bool,
+) {
+    let mut skipped = vec![false; mask.len()];
+    let normal = match (axis, pos_normal) {
+        (0,true) => Vec3::X, (0,false)=> -Vec3::X,
+        (1,true) => Vec3::Y, (1,false)=> -Vec3::Y,
+        (2,true) => Vec3::Z, (2,false)=> -Vec3::Z,
+        _ => Vec3::Z,
+    };
+    let mut y = 0;
+    while y < h {
+        let mut x = 0;
+        while x < w {
+            let idx = (x + y*w) as usize;
+            if mask[idx] && !skipped[idx] {
+                // Find maximal width
+                let mut w_run = 1;
+                while x + w_run < w {
+                    let ii = (x + w_run + y*w) as usize;
+                    if mask[ii] && !skipped[ii] { w_run+=1; } else { break; }
+                }
+                // Find maximal height
+                let mut h_run = 1;
+                'outer: while y + h_run < h {
+                    for xx in x..(x+w_run) {
+                        let jj = (xx + (y+h_run)*w) as usize;
+                        if !mask[jj] || skipped[jj] { break 'outer; }
+                    }
+                    h_run += 1;
+                }
+                // Mark visited
+                for yy in y..(y+h_run) {
+                    for xx in x..(x+w_run) {
+                        skipped[(xx + yy*w) as usize] = true;
+                    }
+                }
+                // Emit quad at rectangle [x..x+w_run), [y..y+h_run)
+                emit_rect(mesh, axis, layer, x, y, w_run, h_run, vm, origin, normal);
+                x += w_run; // advance past rect
+            } else {
+                x += 1;
+            }
+        }
+        y += 1;
+    }
+}
+
+fn emit_rect(
+    mesh: &mut MeshBuffers,
+    axis: u32,
+    layer: u32,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+    vm: f32,
+    origin: Vec3,
+    normal: Vec3,
+) {
+    // Compute the 4 corners in voxel space at face plane
+    let (ax_u, ax_v, ax_w) = match axis {
+        0 => (Vec3::Y, Vec3::Z, Vec3::X),
+        1 => (Vec3::X, Vec3::Z, Vec3::Y),
+        _ => (Vec3::X, Vec3::Y, Vec3::Z),
+    };
+    // layer is along ax_w
+    let base = ax_w * (layer as f32);
+    let p0 = base + ax_u * (x as f32)       + ax_v * (y as f32);
+    let p1 = base + ax_u * ((x+w) as f32)   + ax_v * (y as f32);
+    let p2 = base + ax_u * ((x+w) as f32)   + ax_v * ((y+h) as f32);
+    let p3 = base + ax_u * (x as f32)       + ax_v * ((y+h) as f32);
+    let add = |mesh: &mut MeshBuffers, p: Vec3, n: Vec3| {
+        let wm = origin + p*vm; // place on voxel edge lines in meters
+        mesh.positions.push([wm.x, wm.y, wm.z]);
+        mesh.normals.push([n.x, n.y, n.z]);
+    };
+    let i0 = mesh.positions.len() as u32;
+    add(mesh, p0, normal);
+    add(mesh, p1, normal);
+    add(mesh, p2, normal);
+    add(mesh, p3, normal);
+    // Two triangles (i0,i1,i2) and (i0,i2,i3)
+    mesh.indices.extend_from_slice(&[i0, i0+1, i0+2, i0, i0+2, i0+3]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::{DVec3, UVec3};
+    use voxel_proxy::{VoxelProxyMeta, GlobalId};
+    use core_units::Length;
+    use core_materials::find_material_id;
+
+    fn mk_full_grid(d: UVec3) -> voxel_proxy::VoxelGrid {
+        let meta = VoxelProxyMeta {
+            object_id: GlobalId(1), origin_m: DVec3::ZERO, voxel_m: Length::meters(1.0),
+            dims: d, chunk: UVec3::new(16,16,16), material: find_material_id("stone").unwrap()
+        };
+        let mut g = voxel_proxy::VoxelGrid::new(meta);
+        for z in 0..d.z { for y in 0..d.y { for x in 0..d.x { g.set(x,y,z,true); }}}
+        g
+    }
+
+    #[test]
+    fn solid_cube_produces_six_quads() {
+        let g = mk_full_grid(UVec3::new(3,3,3));
+        let m = greedy_mesh_all(&g);
+        assert_eq!(m.quad_count(), 6);
+    }
+
+    #[test]
+    fn rod_1x1x8_produces_six_quads() {
+        let mut g = mk_full_grid(UVec3::new(1,1,8));
+        // Already filled by mk_full_grid; just mesh
+        let m = greedy_mesh_all(&g);
+        assert_eq!(m.quad_count(), 6);
+    }
+}

--- a/crates/voxel_mesh/src/lib.rs
+++ b/crates/voxel_mesh/src/lib.rs
@@ -265,4 +265,20 @@ mod tests {
         let m = greedy_mesh_all(&g);
         assert_eq!(m.quad_count(), 6);
     }
+
+    #[test]
+    fn single_voxel_produces_36_indices() {
+        let meta = VoxelProxyMeta {
+            object_id: GlobalId(1),
+            origin_m: DVec3::ZERO,
+            voxel_m: Length::meters(1.0),
+            dims: UVec3::new(1, 1, 1),
+            chunk: UVec3::new(1, 1, 1),
+            material: find_material_id("stone").unwrap(),
+        };
+        let mut g = voxel_proxy::VoxelGrid::new(meta);
+        g.set(0, 0, 0, true);
+        let m = greedy_mesh_all(&g);
+        assert_eq!(m.indices.len(), 36);
+    }
 }

--- a/crates/voxel_proxy/Cargo.toml
+++ b/crates/voxel_proxy/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "voxel_proxy"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+core_materials = { version = "0.1.0", path = "../core_materials" }
+core_units = { version = "0.1.0", path = "../core_units" }
+glam = { version = "0.30.8", features = ["serde"] }

--- a/crates/voxel_proxy/src/lib.rs
+++ b/crates/voxel_proxy/src/lib.rs
@@ -1,0 +1,286 @@
+//! voxel_proxy: chunked voxel grid + flood-fill voxelization and carve ops.
+//!
+//! Scope
+//! - VoxelProxyMeta: metadata tying a grid to a design object + units/material.
+//! - VoxelGrid: occupancy in chunked layout (u8 0/1 for P0 uniform material).
+//! - Voxelization helpers: surface mark + flood-fill to produce solid occupancy.
+//! - Carve ops: `carve_sphere` that clears voxels, tracks dirty chunks, and returns
+//!   removed centers (for debris sampling upstream).
+//!
+//! Extending
+//! - Optional per-voxel material palette (`u8`) in P1.
+//! - Cache/load proxies by hash of (mesh, voxel size) when `--cache-proxy` is on.
+
+#![forbid(unsafe_code)]
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use core::cmp::{max, min};
+use core_units::{Length, Mass};
+use core_materials::{MaterialId, mass_for_voxel};
+use glam::{DVec3, UVec3, Vec3};
+use std::collections::{HashSet, VecDeque};
+
+/// Stable global identifier for a design object.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct GlobalId(pub u64);
+
+/// Proxy metadata for a destructible object.
+#[derive(Clone, Debug)]
+pub struct VoxelProxyMeta {
+    pub object_id: GlobalId,
+    pub origin_m: DVec3,
+    pub voxel_m: Length,
+    pub dims: UVec3,
+    pub chunk: UVec3,
+    pub material: MaterialId,
+}
+
+/// Chunked voxel grid with uniform material (P0).
+#[derive(Clone)]
+pub struct VoxelGrid {
+    meta: VoxelProxyMeta,
+    /// Occupancy: 0 = empty, 1 = solid.
+    occ: Vec<u8>,
+    /// Dirty chunk coordinates flagged for remesh/collider update.
+    dirty_chunks: HashSet<(u32, u32, u32)>,
+}
+
+impl VoxelGrid {
+    /// Create an empty grid with given meta.
+    pub fn new(meta: VoxelProxyMeta) -> Self {
+        let len = (meta.dims.x as usize) * (meta.dims.y as usize) * (meta.dims.z as usize);
+        Self { meta, occ: vec![0; len], dirty_chunks: HashSet::new() }
+    }
+
+    /// Linear index for (x,y,z).
+    #[inline]
+    pub fn index(&self, x: u32, y: u32, z: u32) -> usize {
+        let d = self.meta.dims;
+        (x as usize) + (y as usize) * (d.x as usize) + (z as usize) * (d.x as usize) * (d.y as usize)
+    }
+
+    /// Mark occupancy at (x,y,z).
+    #[inline]
+    pub fn set(&mut self, x: u32, y: u32, z: u32, solid: bool) {
+        let idx = self.index(x, y, z);
+        self.occ[idx] = if solid { 1 } else { 0 };
+        if solid {
+            self.mark_chunk_dirty_xyz(x, y, z);
+        }
+    }
+
+    /// Read occupancy at (x,y,z).
+    #[inline]
+    pub fn is_solid(&self, x: u32, y: u32, z: u32) -> bool {
+        self.occ[self.index(x, y, z)] != 0
+    }
+
+    /// Compute chunk coordinate for voxel coord.
+    #[inline]
+    pub fn chunk_of(&self, x: u32, y: u32, z: u32) -> UVec3 {
+        let c = self.meta.chunk;
+        UVec3::new(x / c.x.max(1), y / c.y.max(1), z / c.z.max(1))
+    }
+
+    #[inline]
+    fn mark_chunk_dirty_xyz(&mut self, x: u32, y: u32, z: u32) {
+        let cc = self.chunk_of(x, y, z);
+        self.dirty_chunks.insert((cc.x, cc.y, cc.z));
+    }
+
+    /// Pop up to `n` dirty chunks to process this frame.
+    pub fn pop_dirty_chunks(&mut self, n: usize) -> Vec<UVec3> {
+        let mut out = Vec::new();
+        for _ in 0..n {
+            if let Some(&(x, y, z)) = self.dirty_chunks.iter().next() {
+                self.dirty_chunks.take(&(x, y, z));
+                out.push(UVec3::new(x, y, z));
+            } else {
+                break;
+            }
+        }
+        out
+    }
+
+    /// Total solid voxels.
+    pub fn solid_count(&self) -> usize { self.occ.iter().filter(|&&b| b != 0).count() }
+
+    /// Estimate debris mass for one voxel (helper for upstream usage/tests).
+    pub fn voxel_mass(&self) -> Mass { core_materials::mass_for_voxel(self.meta.material, self.meta.voxel_m).unwrap() }
+}
+
+/// Builds a voxel grid by marking a watertight surface then flood-filling interior.
+pub fn voxelize_surface_fill(
+    meta: VoxelProxyMeta,
+    surface_marks: &[u8], // 0/1 array sized dims.x*dims.y*dims.z
+    close_surfaces: bool,
+) -> VoxelGrid {
+    let mut grid = VoxelGrid::new(meta);
+    let d = grid.meta.dims;
+    assert_eq!(surface_marks.len(), (d.x as usize) * (d.y as usize) * (d.z as usize));
+
+    // Optionally dilate by 1 voxel to close small leaks.
+    let mut surf = surface_marks.to_vec();
+    if close_surfaces {
+        let mut dil = surf.clone();
+        for z in 0..d.z {
+            for y in 0..d.y {
+                for x in 0..d.x {
+                    let idx = grid.index(x, y, z);
+                    if surf[idx] != 0 { continue; }
+                    // if any 6-neighbor is surface, mark
+                    let nbs = neighbors6(x, y, z, d);
+                    if nbs.into_iter().any(|(nx, ny, nz)| surf[grid.index(nx, ny, nz)] != 0) {
+                        dil[idx] = 1;
+                    }
+                }
+            }
+        }
+        surf = dil;
+    }
+
+    // BFS flood from boundary through empty to mark outside.
+    let mut outside = vec![0u8; surf.len()];
+    let mut q = VecDeque::new();
+    // seed all boundary cells that are not surface
+    for z in 0..d.z { for y in 0..d.y { for x in 0..d.x {
+        if x==0 || y==0 || z==0 || x==d.x-1 || y==d.y-1 || z==d.z-1 {
+            let idx = grid.index(x,y,z);
+            if surf[idx]==0 && outside[idx]==0 { outside[idx]=1; q.push_back((x,y,z)); }
+        }
+    }}}
+    while let Some((x,y,z)) = q.pop_front() {
+        for (nx,ny,nz) in neighbors6(x,y,z,d) {
+            let i = grid.index(nx,ny,nz);
+            if surf[i]==0 && outside[i]==0 { outside[i]=1; q.push_back((nx,ny,nz)); }
+        }
+    }
+    // Cells not marked outside are interior or surface -> solid
+    for z in 0..d.z { for y in 0..d.y { for x in 0..d.x {
+        let idx = grid.index(x,y,z);
+        if outside[idx]==0 { grid.set(x,y,z,true); }
+    }}}
+    grid
+}
+
+/// Remove voxels within a sphere; return removed centers and touched chunks.
+pub fn carve_sphere(grid: &mut VoxelGrid, center_m: DVec3, radius: Length) -> RemovedVoxels {
+    let d = grid.meta.dims;
+    let vm = grid.meta.voxel_m.0;
+    let r = radius.0;
+    let r2 = r*r;
+    // Compute voxel-space AABB bounds
+    let to_voxel = |p: DVec3| -> Vec3 { ((p - grid.meta.origin_m) / vm).as_vec3() };
+    let c_v = to_voxel(center_m);
+    let min_v = c_v - Vec3::splat((r/vm) + 1.0);
+    let max_v = c_v + Vec3::splat((r/vm) + 1.0);
+    let xi0 = max(min_v.x.floor() as i32, 0) as u32;
+    let yi0 = max(min_v.y.floor() as i32, 0) as u32;
+    let zi0 = max(min_v.z.floor() as i32, 0) as u32;
+    let xi1 = min(max_v.x.ceil() as u32, d.x-1);
+    let yi1 = min(max_v.y.ceil() as u32, d.y-1);
+    let zi1 = min(max_v.z.ceil() as u32, d.z-1);
+    let mut removed_centers = Vec::new();
+    let mut chunks = HashSet::new();
+    for z in zi0..=zi1 { for y in yi0..=yi1 { for x in xi0..=xi1 {
+        // center of voxel in meters
+        let p_m = grid.meta.origin_m + DVec3::new((x as f64 + 0.5)*vm, (y as f64 + 0.5)*vm, (z as f64 + 0.5)*vm);
+        let d2 = (p_m - center_m).length_squared();
+        if d2 <= r2 && grid.is_solid(x,y,z) {
+            // clear
+            let idx = grid.index(x,y,z);
+            grid.occ[idx]=0; // cleared
+            let cc = grid.chunk_of(x,y,z);
+            chunks.insert((cc.x,cc.y,cc.z));
+            removed_centers.push(p_m);
+        }
+    }}}
+    for (x,y,z) in &chunks { grid.dirty_chunks.insert((*x,*y,*z)); }
+    RemovedVoxels { centers_m: removed_centers, chunks_touched: chunks.into_iter().map(|(x,y,z)| UVec3::new(x,y,z)).collect() }
+}
+
+/// Summary of carve operation for debris spawning and remesh scheduling.
+pub struct RemovedVoxels {
+    pub centers_m: Vec<DVec3>,
+    pub chunks_touched: Vec<UVec3>,
+}
+
+#[inline]
+fn neighbors6(x: u32, y: u32, z: u32, d: UVec3) -> Small6 {
+    let mut out = Small6 { n: 0, v: [(0,0,0); 6] };
+    let mut push = |xx:u32,yy:u32,zz:u32, out: &mut Small6| { out.v[out.n] = (xx,yy,zz); out.n+=1; };
+    if x>0       { push(x-1,y ,z , &mut out); }
+    if x+1<d.x   { push(x+1,y ,z , &mut out); }
+    if y>0       { push(x ,y-1,z , &mut out); }
+    if y+1<d.y   { push(x ,y+1,z , &mut out); }
+    if z>0       { push(x ,y ,z-1, &mut out); }
+    if z+1<d.z   { push(x ,y ,z+1, &mut out); }
+    out
+}
+
+struct Small6 { n: usize, v: [(u32,u32,u32); 6] }
+impl IntoIterator for Small6 {
+    type Item = (u32,u32,u32);
+    type IntoIter = core::array::IntoIter<(u32,u32,u32), 6>;
+    fn into_iter(self) -> Self::IntoIter { self.v.into_iter().take(self.n) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_meta(d: UVec3, c: UVec3) -> VoxelProxyMeta {
+        VoxelProxyMeta {
+            object_id: GlobalId(1),
+            origin_m: DVec3::ZERO,
+            voxel_m: Length::meters(0.1),
+            dims: d,
+            chunk: c,
+            material: core_materials::find_material_id("stone").unwrap(),
+        }
+    }
+
+    #[test]
+    fn indexing_round_trip() {
+        let meta = mk_meta(UVec3::new(8,9,10), UVec3::new(4,4,4));
+        let mut g = VoxelGrid::new(meta);
+        for z in 0..10 { for y in 0..9 { for x in 0..8 {
+            let i = g.index(x,y,z);
+            g.occ[i] = 1;
+            assert!(g.is_solid(x,y,z));
+        }}}
+        assert_eq!(g.solid_count(), 8*9*10);
+    }
+
+    #[test]
+    fn flood_fill_cube_shell_fills_interior() {
+        let d = UVec3::new(16,16,16);
+        let meta = mk_meta(d, UVec3::new(8,8,8));
+        let mut surf = vec![0u8; (d.x*d.y*d.z) as usize];
+        // inner box spans [2..=13] each axis; mark its surface cells
+        let mut idx = |x:u32,y:u32,z:u32| -> usize { (x + y*d.x + z*d.x*d.y) as usize };
+        for z in 2..=13 { for y in 2..=13 { for x in 2..=13 {
+            if x==2 || x==13 || y==2 || y==13 || z==2 || z==13 { surf[idx(x,y,z)] = 1; }
+        }}}
+        let g = voxelize_surface_fill(meta, &surf, false);
+        // expected solids = volume of 12^3 cube (including surface) = 1728
+        assert_eq!(g.solid_count(), 12*12*12);
+    }
+
+    #[test]
+    fn carve_sphere_marks_dirty_chunks_across_boundary() {
+        let d = UVec3::new(32,16,16);
+        let meta = mk_meta(d, UVec3::new(16,16,16));
+        // Fill entire grid solid
+        let mut g = VoxelGrid::new(meta);
+        for z in 0..d.z { for y in 0..d.y { for x in 0..d.x { g.set(x,y,z,true); }}}
+        // Carve a sphere centered near x=16 boundary to touch both chunks
+        let center = DVec3::new(16.0 * g.meta.voxel_m.0, (d.y as f64)*g.meta.voxel_m.0*0.5, (d.z as f64)*g.meta.voxel_m.0*0.5);
+        let _removed = carve_sphere(&mut g, center, Length::meters(0.5));
+        let dirty = g.pop_dirty_chunks(16);
+        // Expect at least two distinct chunk x-coordinates
+        let mut xs: HashSet<u32> = HashSet::new();
+        for c in dirty { xs.insert(c.x); }
+        assert!(xs.len()>=2, "expected carve to touch chunks across boundary");
+    }
+}


### PR DESCRIPTION
This PR scaffolds the voxel pipeline per Issue #75 approvals. It introduces CPU-only crates with solid unit tests to unblock wiring the projectile → carve → debris loop and chunked remeshing.

What’s included
- crates/voxel_proxy
  - VoxelProxyMeta (object id, origin, dims, chunk size, voxel size, uniform MaterialId).
  - VoxelGrid (u8 occupancy, chunk-aware dirty set).
  - voxelize_surface_fill(surface_marks, close_surfaces): surface+flood-fill voxelization to produce solids.
  - carve_sphere(center_m, radius): clears voxels within a sphere, returns RemovedVoxels { centers_m, chunks_touched } and flags dirty chunks.
  - Helpers: linear indexing, chunk_of, pop_dirty_chunks, voxel_mass().
- crates/voxel_mesh
  - greedy_mesh_all(&VoxelGrid) → MeshBuffers { positions, normals, indices }: extracts faces on solid→empty boundaries and greedily merges co-planar rectangles per slice (±X/±Y/±Z).

Tests
- voxel_proxy
  - indexing_round_trip over a 3D grid.
  - flood_fill_cube_shell_fills_interior: inner 12^3 cube shell (in 16^3 grid) fills to 12^3 solids (interior+surface).
  - carve_sphere_marks_dirty_chunks_across_boundary: sphere at x=16 touches ≥2 chunk x’s.
- voxel_mesh
  - solid_cube_produces_six_quads: a 3×3×3 solid produces 6 quads.
  - rod_1x1x8_produces_six_quads: a 1×1×8 solid produces 6 quads.

Notes
- P0 keeps uniform material (u8 occ); per-voxel palette can follow in P1.
- Meshing operates on the entire grid for now; next PR adds per-chunk meshing using VoxelGrid’s dirty set.
- All types use meters via core_units::Length at boundaries; f32 only when producing vertex arrays.

Next steps
- voxel_mesh: per-chunk meshing entrypoints + return chunk-local MeshBuffers.
- collision_static::chunks: build/swap static colliders per dirty chunk.
- server_core: projectile DDA → carve_sphere → debris spawn (seeded RNG).
- CLI flags + debug overlay (F3) integration in the app.
