### PR TITLE
voxel: per-chunk meshing API + coarse chunk colliders (AABB OBB)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,6 +1643,7 @@ dependencies = [
  "approx",
  "glam 0.30.8",
  "smallvec",
+ "voxel_proxy",
 ]
 
 [[package]]

--- a/crates/collision_static/Cargo.toml
+++ b/crates/collision_static/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 glam = "0.30"
 smallvec = "1"
+voxel_proxy = { version = "0.1.0", path = "../voxel_proxy" }
 
 [dev-dependencies]
 approx = "0.5"

--- a/crates/collision_static/src/chunks.rs
+++ b/crates/collision_static/src/chunks.rs
@@ -91,10 +91,8 @@ pub fn swap_in_updates(store: &mut Vec<StaticChunk>, updates: Vec<StaticChunk>) 
 }
 
 /// Flatten chunk colliders into a `StaticIndex` for queries.
-pub fn rebuild_static_index(store: &Vec<StaticChunk>) -> StaticIndex {
-    let mut idx = StaticIndex::default();
-    idx.colliders = store.iter().map(|c| c.collider).collect();
-    idx
+pub fn rebuild_static_index(store: &[StaticChunk]) -> StaticIndex {
+    StaticIndex { colliders: store.iter().map(|c| c.collider).collect() }
 }
 
 #[cfg(test)]

--- a/crates/collision_static/src/chunks.rs
+++ b/crates/collision_static/src/chunks.rs
@@ -92,7 +92,9 @@ pub fn swap_in_updates(store: &mut Vec<StaticChunk>, updates: Vec<StaticChunk>) 
 
 /// Flatten chunk colliders into a `StaticIndex` for queries.
 pub fn rebuild_static_index(store: &[StaticChunk]) -> StaticIndex {
-    StaticIndex { colliders: store.iter().map(|c| c.collider).collect() }
+    StaticIndex {
+        colliders: store.iter().map(|c| c.collider).collect(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/collision_static/src/chunks.rs
+++ b/crates/collision_static/src/chunks.rs
@@ -1,0 +1,123 @@
+//! chunks: helpers to build and manage coarse colliders per voxel chunk.
+//!
+//! P0 goal is a fast, coarse approximation for debris-vs-world preview: one OBB per
+//! dirty chunk AABB. This keeps broadphase simple and avoids per-triangle cost.
+//!
+//! Extending later: finer collision derived from meshed surfaces.
+
+use crate::{Aabb, OBB, ShapeRef, StaticCollider, StaticIndex};
+use glam::{Mat3, UVec3, Vec3};
+use voxel_proxy::VoxelGrid;
+
+/// A collider tied to a chunk coordinate.
+#[derive(Clone, Debug)]
+pub struct StaticChunk {
+    pub coord: UVec3,
+    pub collider: StaticCollider,
+}
+
+/// Compute world-space AABB for a given chunk.
+pub fn chunk_world_aabb(grid: &VoxelGrid, coord: UVec3) -> Aabb {
+    let (xr, yr, zr) = grid.chunk_bounds_voxels(coord);
+    let vox = grid.voxel_m().0 as f32;
+    let o = grid.origin_m().as_vec3();
+    let min = o + Vec3::new(xr.start as f32 * vox, yr.start as f32 * vox, zr.start as f32 * vox);
+    let max = o + Vec3::new(xr.end as f32 * vox, yr.end as f32 * vox, zr.end as f32 * vox);
+    Aabb { min, max }
+}
+
+/// Build a coarse OBB collider for a chunk if any voxel in the chunk is solid.
+pub fn build_chunk_collider(grid: &VoxelGrid, coord: UVec3) -> Option<StaticChunk> {
+    let (xr, yr, zr) = grid.chunk_bounds_voxels(coord);
+    let mut any = false;
+    for z in zr.clone() {
+        for y in yr.clone() {
+            for x in xr.clone() {
+                if grid.is_solid(x, y, z) { any = true; break; }
+            }
+            if any { break; }
+        }
+        if any { break; }
+    }
+    if !any { return None; }
+    let aabb = chunk_world_aabb(grid, coord);
+    let center = (aabb.min + aabb.max) * 0.5;
+    let half_extents = (aabb.max - aabb.min) * 0.5;
+    let rot3x3 = Mat3::IDENTITY;
+    let collider = StaticCollider { aabb, shape: ShapeRef::Box(OBB { center, half_extents, rot3x3 }) };
+    Some(StaticChunk { coord, collider })
+}
+
+/// Replace stored chunk colliders by coord with the provided updates (one per coord).
+pub fn swap_in_updates(store: &mut Vec<StaticChunk>, updates: Vec<StaticChunk>) {
+    use std::collections::HashMap;
+    let mut map: HashMap<(u32,u32,u32), usize> = HashMap::new();
+    for (i, c) in store.iter().enumerate() {
+        map.insert((c.coord.x, c.coord.y, c.coord.z), i);
+    }
+    for up in updates {
+        let key = (up.coord.x, up.coord.y, up.coord.z);
+        if let Some(idx) = map.get(&key).copied() {
+            store[idx] = up;
+        } else {
+            map.insert(key, store.len());
+            store.push(up);
+        }
+    }
+}
+
+/// Flatten chunk colliders into a `StaticIndex` for queries.
+pub fn rebuild_static_index(store: &Vec<StaticChunk>) -> StaticIndex {
+    let mut idx = StaticIndex::default();
+    idx.colliders = store.iter().map(|c| c.collider).collect();
+    idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_materials::find_material_id;
+    use core_units::Length;
+    use glam::{DVec3, UVec3};
+    use voxel_proxy::{GlobalId, VoxelProxyMeta};
+
+    fn mk_grid(d: UVec3, c: UVec3) -> VoxelGrid {
+        let meta = VoxelProxyMeta {
+            object_id: GlobalId(1), origin_m: DVec3::ZERO, voxel_m: Length::meters(1.0),
+            dims: d, chunk: c, material: find_material_id("stone").unwrap()
+        };
+        VoxelGrid::new(meta)
+    }
+
+    #[test]
+    fn empty_chunk_yields_none() {
+        let g = mk_grid(UVec3::new(32,16,16), UVec3::new(16,16,16));
+        assert!(build_chunk_collider(&g, UVec3::new(1,0,0)).is_none());
+    }
+
+    #[test]
+    fn solid_voxel_in_chunk_yields_aabb_collider() {
+        let mut g = mk_grid(UVec3::new(32,16,16), UVec3::new(16,16,16));
+        // Put a single solid in chunk (1,0,0)
+        g.set(17, 0, 0, true);
+        let c = build_chunk_collider(&g, UVec3::new(1,0,0)).expect("has collider");
+        let aabb = c.collider.aabb;
+        assert!(aabb.max.x > aabb.min.x);
+        assert!(aabb.max.y > aabb.min.y);
+        assert!(aabb.max.z > aabb.min.z);
+    }
+
+    #[test]
+    fn swap_and_rebuild_index() {
+        let mut store: Vec<StaticChunk> = Vec::new();
+        let aabb0 = Aabb { min: Vec3::splat(0.0), max: Vec3::splat(1.0) };
+        let obb = OBB { center: Vec3::splat(0.5), half_extents: Vec3::splat(0.5), rot3x3: Mat3::IDENTITY };
+        swap_in_updates(&mut store, vec![StaticChunk { coord: UVec3::new(0,0,0), collider: StaticCollider { aabb: aabb0, shape: ShapeRef::Box(obb) } }]);
+        swap_in_updates(&mut store, vec![StaticChunk { coord: UVec3::new(1,0,0), collider: StaticCollider { aabb: aabb0, shape: ShapeRef::Box(obb) } }]);
+        // Replace first
+        swap_in_updates(&mut store, vec![StaticChunk { coord: UVec3::new(0,0,0), collider: StaticCollider { aabb: Aabb { min: Vec3::splat(1.0), max: Vec3::splat(2.0) }, shape: ShapeRef::Box(obb) } }]);
+        let idx = rebuild_static_index(&store);
+        assert_eq!(idx.colliders.len(), 2);
+    }
+}
+

--- a/crates/collision_static/src/chunks.rs
+++ b/crates/collision_static/src/chunks.rs
@@ -21,8 +21,16 @@ pub fn chunk_world_aabb(grid: &VoxelGrid, coord: UVec3) -> Aabb {
     let (xr, yr, zr) = grid.chunk_bounds_voxels(coord);
     let vox = grid.voxel_m().0 as f32;
     let o = grid.origin_m().as_vec3();
-    let min = o + Vec3::new(xr.start as f32 * vox, yr.start as f32 * vox, zr.start as f32 * vox);
-    let max = o + Vec3::new(xr.end as f32 * vox, yr.end as f32 * vox, zr.end as f32 * vox);
+    let min = o + Vec3::new(
+        xr.start as f32 * vox,
+        yr.start as f32 * vox,
+        zr.start as f32 * vox,
+    );
+    let max = o + Vec3::new(
+        xr.end as f32 * vox,
+        yr.end as f32 * vox,
+        zr.end as f32 * vox,
+    );
     Aabb { min, max }
 }
 
@@ -33,25 +41,41 @@ pub fn build_chunk_collider(grid: &VoxelGrid, coord: UVec3) -> Option<StaticChun
     for z in zr.clone() {
         for y in yr.clone() {
             for x in xr.clone() {
-                if grid.is_solid(x, y, z) { any = true; break; }
+                if grid.is_solid(x, y, z) {
+                    any = true;
+                    break;
+                }
             }
-            if any { break; }
+            if any {
+                break;
+            }
         }
-        if any { break; }
+        if any {
+            break;
+        }
     }
-    if !any { return None; }
+    if !any {
+        return None;
+    }
     let aabb = chunk_world_aabb(grid, coord);
     let center = (aabb.min + aabb.max) * 0.5;
     let half_extents = (aabb.max - aabb.min) * 0.5;
     let rot3x3 = Mat3::IDENTITY;
-    let collider = StaticCollider { aabb, shape: ShapeRef::Box(OBB { center, half_extents, rot3x3 }) };
+    let collider = StaticCollider {
+        aabb,
+        shape: ShapeRef::Box(OBB {
+            center,
+            half_extents,
+            rot3x3,
+        }),
+    };
     Some(StaticChunk { coord, collider })
 }
 
 /// Replace stored chunk colliders by coord with the provided updates (one per coord).
 pub fn swap_in_updates(store: &mut Vec<StaticChunk>, updates: Vec<StaticChunk>) {
     use std::collections::HashMap;
-    let mut map: HashMap<(u32,u32,u32), usize> = HashMap::new();
+    let mut map: HashMap<(u32, u32, u32), usize> = HashMap::new();
     for (i, c) in store.iter().enumerate() {
         map.insert((c.coord.x, c.coord.y, c.coord.z), i);
     }
@@ -83,24 +107,28 @@ mod tests {
 
     fn mk_grid(d: UVec3, c: UVec3) -> VoxelGrid {
         let meta = VoxelProxyMeta {
-            object_id: GlobalId(1), origin_m: DVec3::ZERO, voxel_m: Length::meters(1.0),
-            dims: d, chunk: c, material: find_material_id("stone").unwrap()
+            object_id: GlobalId(1),
+            origin_m: DVec3::ZERO,
+            voxel_m: Length::meters(1.0),
+            dims: d,
+            chunk: c,
+            material: find_material_id("stone").unwrap(),
         };
         VoxelGrid::new(meta)
     }
 
     #[test]
     fn empty_chunk_yields_none() {
-        let g = mk_grid(UVec3::new(32,16,16), UVec3::new(16,16,16));
-        assert!(build_chunk_collider(&g, UVec3::new(1,0,0)).is_none());
+        let g = mk_grid(UVec3::new(32, 16, 16), UVec3::new(16, 16, 16));
+        assert!(build_chunk_collider(&g, UVec3::new(1, 0, 0)).is_none());
     }
 
     #[test]
     fn solid_voxel_in_chunk_yields_aabb_collider() {
-        let mut g = mk_grid(UVec3::new(32,16,16), UVec3::new(16,16,16));
+        let mut g = mk_grid(UVec3::new(32, 16, 16), UVec3::new(16, 16, 16));
         // Put a single solid in chunk (1,0,0)
         g.set(17, 0, 0, true);
-        let c = build_chunk_collider(&g, UVec3::new(1,0,0)).expect("has collider");
+        let c = build_chunk_collider(&g, UVec3::new(1, 0, 0)).expect("has collider");
         let aabb = c.collider.aabb;
         assert!(aabb.max.x > aabb.min.x);
         assert!(aabb.max.y > aabb.min.y);
@@ -110,14 +138,50 @@ mod tests {
     #[test]
     fn swap_and_rebuild_index() {
         let mut store: Vec<StaticChunk> = Vec::new();
-        let aabb0 = Aabb { min: Vec3::splat(0.0), max: Vec3::splat(1.0) };
-        let obb = OBB { center: Vec3::splat(0.5), half_extents: Vec3::splat(0.5), rot3x3: Mat3::IDENTITY };
-        swap_in_updates(&mut store, vec![StaticChunk { coord: UVec3::new(0,0,0), collider: StaticCollider { aabb: aabb0, shape: ShapeRef::Box(obb) } }]);
-        swap_in_updates(&mut store, vec![StaticChunk { coord: UVec3::new(1,0,0), collider: StaticCollider { aabb: aabb0, shape: ShapeRef::Box(obb) } }]);
+        let aabb0 = Aabb {
+            min: Vec3::splat(0.0),
+            max: Vec3::splat(1.0),
+        };
+        let obb = OBB {
+            center: Vec3::splat(0.5),
+            half_extents: Vec3::splat(0.5),
+            rot3x3: Mat3::IDENTITY,
+        };
+        swap_in_updates(
+            &mut store,
+            vec![StaticChunk {
+                coord: UVec3::new(0, 0, 0),
+                collider: StaticCollider {
+                    aabb: aabb0,
+                    shape: ShapeRef::Box(obb),
+                },
+            }],
+        );
+        swap_in_updates(
+            &mut store,
+            vec![StaticChunk {
+                coord: UVec3::new(1, 0, 0),
+                collider: StaticCollider {
+                    aabb: aabb0,
+                    shape: ShapeRef::Box(obb),
+                },
+            }],
+        );
         // Replace first
-        swap_in_updates(&mut store, vec![StaticChunk { coord: UVec3::new(0,0,0), collider: StaticCollider { aabb: Aabb { min: Vec3::splat(1.0), max: Vec3::splat(2.0) }, shape: ShapeRef::Box(obb) } }]);
+        swap_in_updates(
+            &mut store,
+            vec![StaticChunk {
+                coord: UVec3::new(0, 0, 0),
+                collider: StaticCollider {
+                    aabb: Aabb {
+                        min: Vec3::splat(1.0),
+                        max: Vec3::splat(2.0),
+                    },
+                    shape: ShapeRef::Box(obb),
+                },
+            }],
+        );
         let idx = rebuild_static_index(&store);
         assert_eq!(idx.colliders.len(), 2);
     }
 }
-

--- a/crates/collision_static/src/lib.rs
+++ b/crates/collision_static/src/lib.rs
@@ -193,6 +193,8 @@ fn capsule_vs_obb(_cap: &Capsule, _obb: &OBB) -> Option<Hit> {
     None
 }
 
+pub mod chunks;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/voxel_mesh/src/lib.rs
+++ b/crates/voxel_mesh/src/lib.rs
@@ -75,6 +75,58 @@ pub fn greedy_mesh_all(grid: &VoxelGrid) -> MeshBuffers {
     mesh
 }
 
+/// Generate a meshed surface for a single chunk by filtering the full mesh to triangles
+/// whose centroids belong to the given chunk coordinate. This prioritizes correctness
+/// and chunk ownership of faces; optimized per-slice greedy meshing can layer on later.
+pub fn greedy_mesh_chunk(grid: &VoxelGrid, chunk: UVec3) -> MeshBuffers {
+    let all = greedy_mesh_all(grid);
+    if all.indices.is_empty() {
+        return all;
+    }
+    let (xr, yr, zr) = grid.chunk_bounds_voxels(chunk);
+    let origin = grid.meta().origin_m.as_vec3();
+    let vm = grid.meta().voxel_m.0 as f32;
+    let csz = grid.meta().chunk;
+    let mut keep = Vec::with_capacity(all.indices.len() / 3);
+    // Select triangles whose centroid falls within the chunk voxel bounds
+    for tri in all.indices.chunks_exact(3) {
+        let p0 = Vec3::from(all.positions[tri[0] as usize]);
+        let p1 = Vec3::from(all.positions[tri[1] as usize]);
+        let p2 = Vec3::from(all.positions[tri[2] as usize]);
+        let centroid = (p0 + p1 + p2) / 3.0;
+        let v = (centroid - origin) / vm; // voxel coords (float)
+        let vx = v.x.floor() as i32;
+        let vy = v.y.floor() as i32;
+        let vz = v.z.floor() as i32;
+        if vx >= xr.start as i32 && vx < xr.end as i32
+            && vy >= yr.start as i32 && vy < yr.end as i32
+            && vz >= zr.start as i32 && vz < zr.end as i32
+        {
+            keep.push([tri[0], tri[1], tri[2]]);
+        }
+    }
+    if keep.is_empty() {
+        return MeshBuffers::default();
+    }
+    // Reindex vertices to only include those referenced by kept triangles
+    use std::collections::HashMap;
+    let mut map: HashMap<u32, u32> = HashMap::new();
+    let mut out = MeshBuffers::default();
+    for tri in keep.into_iter() {
+        for &old_i in &tri {
+            let next = *map.entry(old_i).or_insert_with(|| {
+                let p = all.positions[old_i as usize];
+                let n = all.normals[old_i as usize];
+                out.positions.push(p);
+                out.normals.push(n);
+                (out.positions.len() as u32) - 1
+            });
+            out.indices.push(next);
+        }
+    }
+    out
+}
+
 fn plane_dims(axis: u32, d: UVec3) -> (u32, u32, u32, UVec3, UVec3, UVec3) {
     match axis {
         // (w,h,ld)
@@ -280,5 +332,24 @@ mod tests {
         g.set(0, 0, 0, true);
         let m = greedy_mesh_all(&g);
         assert_eq!(m.indices.len(), 36);
+    }
+
+    #[test]
+    fn chunk_mesher_filters_to_correct_chunk() {
+        // 32x16x16 with chunk size 16^3: voxel at x=17,y=2,z=3
+        let meta = VoxelProxyMeta {
+            object_id: GlobalId(1),
+            origin_m: DVec3::ZERO,
+            voxel_m: Length::meters(1.0),
+            dims: UVec3::new(32, 16, 16),
+            chunk: UVec3::new(16, 16, 16),
+            material: find_material_id("stone").unwrap(),
+        };
+        let mut g = voxel_proxy::VoxelGrid::new(meta);
+        g.set(17, 2, 3, true);
+        let m0 = greedy_mesh_chunk(&g, UVec3::new(0, 0, 0));
+        let m1 = greedy_mesh_chunk(&g, UVec3::new(1, 0, 0));
+        assert_eq!(m0.indices.len(), 0);
+        assert_eq!(m1.indices.len(), 36);
     }
 }

--- a/crates/voxel_mesh/src/lib.rs
+++ b/crates/voxel_mesh/src/lib.rs
@@ -98,9 +98,12 @@ pub fn greedy_mesh_chunk(grid: &VoxelGrid, chunk: UVec3) -> MeshBuffers {
         let vx = v.x.floor() as i32;
         let vy = v.y.floor() as i32;
         let vz = v.z.floor() as i32;
-        if vx >= xr.start as i32 && vx < xr.end as i32
-            && vy >= yr.start as i32 && vy < yr.end as i32
-            && vz >= zr.start as i32 && vz < zr.end as i32
+        if vx >= xr.start as i32
+            && vx < xr.end as i32
+            && vy >= yr.start as i32
+            && vy < yr.end as i32
+            && vz >= zr.start as i32
+            && vz < zr.end as i32
         {
             keep.push([tri[0], tri[1], tri[2]]);
         }

--- a/crates/voxel_proxy/src/lib.rs
+++ b/crates/voxel_proxy/src/lib.rs
@@ -15,7 +15,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 use core::cmp::{max, min};
-use core_materials::{MaterialId, mass_for_voxel};
+use core_materials::MaterialId;
 use core_units::{Length, Mass};
 use glam::{DVec3, UVec3, Vec3};
 use std::collections::{HashSet, VecDeque};
@@ -58,19 +58,27 @@ impl VoxelGrid {
 
     /// Access proxy metadata.
     #[inline]
-    pub fn meta(&self) -> &VoxelProxyMeta { &self.meta }
+    pub fn meta(&self) -> &VoxelProxyMeta {
+        &self.meta
+    }
 
     /// Grid dimensions (voxels).
     #[inline]
-    pub fn dims(&self) -> UVec3 { self.meta.dims }
+    pub fn dims(&self) -> UVec3 {
+        self.meta.dims
+    }
 
     /// Grid origin in meters.
     #[inline]
-    pub fn origin_m(&self) -> DVec3 { self.meta.origin_m }
+    pub fn origin_m(&self) -> DVec3 {
+        self.meta.origin_m
+    }
 
     /// Voxel edge length in meters.
     #[inline]
-    pub fn voxel_m(&self) -> Length { self.meta.voxel_m }
+    pub fn voxel_m(&self) -> Length {
+        self.meta.voxel_m
+    }
 
     /// Linear index for (x,y,z).
     #[inline]
@@ -106,7 +114,14 @@ impl VoxelGrid {
     }
 
     /// Bounds (start..end) in voxel coordinates for a given chunk coordinate.
-    pub fn chunk_bounds_voxels(&self, chunk: UVec3) -> (core::ops::Range<u32>, core::ops::Range<u32>, core::ops::Range<u32>) {
+    pub fn chunk_bounds_voxels(
+        &self,
+        chunk: UVec3,
+    ) -> (
+        core::ops::Range<u32>,
+        core::ops::Range<u32>,
+        core::ops::Range<u32>,
+    ) {
         let d = self.meta.dims;
         let c = self.meta.chunk;
         let x0 = chunk.x.saturating_mul(c.x);
@@ -150,7 +165,9 @@ impl VoxelGrid {
 
     /// Number of dirty chunks currently queued.
     #[inline]
-    pub fn dirty_len(&self) -> usize { self.dirty_chunks.len() }
+    pub fn dirty_len(&self) -> usize {
+        self.dirty_chunks.len()
+    }
 
     /// Bounds check helper.
     #[inline]
@@ -185,7 +202,10 @@ pub fn voxelize_surface_fill(
                     }
                     // if any 6-neighbor is surface, mark
                     let nbs = neighbors6(x, y, z, d);
-                    if nbs.iter().any(|&(nx, ny, nz)| surf[grid.index(nx, ny, nz)] != 0) {
+                    if nbs
+                        .iter()
+                        .any(|&(nx, ny, nz)| surf[grid.index(nx, ny, nz)] != 0)
+                    {
                         dil[idx] = 1;
                     }
                 }
@@ -306,7 +326,7 @@ fn neighbors6(x: u32, y: u32, z: u32, d: UVec3) -> Small6 {
         n: 0,
         v: [(0, 0, 0); 6],
     };
-    let mut push = |xx: u32, yy: u32, zz: u32, out: &mut Small6| {
+    let push = |xx: u32, yy: u32, zz: u32, out: &mut Small6| {
         out.v[out.n] = (xx, yy, zz);
         out.n += 1;
     };
@@ -337,7 +357,9 @@ struct Small6 {
 }
 impl Small6 {
     #[inline]
-    fn iter(&self) -> core::slice::Iter<'_, (u32, u32, u32)> { self.v[..self.n].iter() }
+    fn iter(&self) -> core::slice::Iter<'_, (u32, u32, u32)> {
+        self.v[..self.n].iter()
+    }
 }
 
 #[cfg(test)]
@@ -426,14 +448,14 @@ mod tests {
 
     #[test]
     fn close_surfaces_preserves_surface_voxels() {
-        let d = UVec3::new(8,8,8);
-        let meta = mk_meta(d, UVec3::new(4,4,4));
-        let mut surf = vec![0u8; (d.x*d.y*d.z) as usize];
+        let d = UVec3::new(8, 8, 8);
+        let meta = mk_meta(d, UVec3::new(4, 4, 4));
+        let mut surf = vec![0u8; (d.x * d.y * d.z) as usize];
         // Mark a single surface voxel in the center
-        let idx = |x:u32,y:u32,z:u32| -> usize { (x + y*d.x + z*d.x*d.y) as usize };
-        surf[idx(4,4,4)] = 1;
+        let idx = |x: u32, y: u32, z: u32| -> usize { (x + y * d.x + z * d.x * d.y) as usize };
+        surf[idx(4, 4, 4)] = 1;
         let g = voxelize_surface_fill(meta, &surf, true);
         // The marked cell should remain solid after dilation + flood fill
-        assert!(g.is_solid(4,4,4));
+        assert!(g.is_solid(4, 4, 4));
     }
 }


### PR DESCRIPTION
This PR implements the next phase for Issue #75: per-chunk meshing entrypoints and coarse chunk collider helpers under `collision_static` to support budgeted remesh + collider refresh.

What’s included
- voxel_proxy
  - `chunk_bounds_voxels(chunk)`: returns voxel ranges for a chunk.
  - Minor accessors (`meta`, `dims`, `origin_m`, `voxel_m`, `dirty_len`, `inside`).
  - Close-surfaces dilation OR fix and tests (from last PR).
- voxel_mesh
  - `greedy_mesh_chunk(&VoxelGrid, chunk: UVec3) -> MeshBuffers`: filters the full greedy mesh to triangles whose centroids fall within the target chunk’s voxel bounds. This yields correct chunk ownership without double-emission across boundaries; a slice-limited greedy pass can replace it later if needed.
  - Tests:
    - `chunk_mesher_filters_to_correct_chunk` (32×16×16, chunk 16³; single voxel at x=17 goes to chunk (1,0,0)).
    - `single_voxel_produces_36_indices` retained to assert baseline faces.
- collision_static::chunks (new module)
  - `chunk_world_aabb(&VoxelGrid, chunk) -> Aabb`: compute world-space AABB of a chunk.
  - `build_chunk_collider(&VoxelGrid, chunk) -> Option<StaticChunk>`: if any voxel is solid in the chunk, produce a coarse OBB (aligned to AABB) for fast broadphase/preview collisions.
  - `swap_in_updates` + `rebuild_static_index`: basic store management for chunk colliders.
  - Tests for empty/solid chunk and store rebuild.

Why this approach
- Keeps chunk ownership deterministic and simple; avoids emitting faces twice across chunk boundaries.
- Coarse OBB per-chunk collider is cheap, good enough for P0 debris-ground/world previews; later can refine to surface-derived colliders while keeping the API.

Notes
- All new functionality is CPU-only, with thorough unit tests.
- No changes to runtime wiring yet. Next PR will hook projectile DDA → carve_sphere → debris spawn and schedule per-chunk remesh/collider rebuilds behind a budget.

CI
- `xtask ci` (fmt, clippy -D warnings, WGSL validation, tests) passes locally.
