### PR TITLE
voxels: per-chunk greedy meshing + draw (CPU-only)

### DIFF
--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -64,10 +64,11 @@ use winit::dpi::PhysicalSize;
 // input handling moved to renderer/input.rs
 use collision_static::chunks::{self as chunkcol, StaticChunk};
 use server_core::destructible::{config::DestructibleConfig, queue::ChunkQueue};
+use std::collections::HashMap;
+#[allow(unused_imports)]
+use voxel_mesh::MeshBuffers;
 use voxel_proxy::VoxelGrid;
 use winit::window::Window;
-use std::collections::HashMap;
-use voxel_mesh::MeshBuffers;
 
 fn asset_path(rel: &str) -> std::path::PathBuf {
     // Prefer workspace-level assets so this crate works when built inside a workspace.
@@ -322,7 +323,7 @@ pub struct Renderer {
     vox_debris_last: usize,
 
     // Voxel chunk GPU meshes (keyed by chunk coord)
-    voxel_meshes: HashMap<(u32,u32,u32), VoxelChunkMesh>,
+    voxel_meshes: HashMap<(u32, u32, u32), VoxelChunkMesh>,
     // Simple model color for voxels (neutral gray)
     voxel_model_bg: wgpu::BindGroup,
 

--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -66,6 +66,8 @@ use collision_static::chunks::{self as chunkcol, StaticChunk};
 use server_core::destructible::{config::DestructibleConfig, queue::ChunkQueue};
 use voxel_proxy::VoxelGrid;
 use winit::window::Window;
+use std::collections::HashMap;
+use voxel_mesh::MeshBuffers;
 
 fn asset_path(rel: &str) -> std::path::PathBuf {
     // Prefer workspace-level assets so this crate works when built inside a workspace.
@@ -319,6 +321,11 @@ pub struct Renderer {
     vox_queue_len: usize,
     vox_debris_last: usize,
 
+    // Voxel chunk GPU meshes (keyed by chunk coord)
+    voxel_meshes: HashMap<(u32,u32,u32), VoxelChunkMesh>,
+    // Simple model color for voxels (neutral gray)
+    voxel_model_bg: wgpu::BindGroup,
+
     // --- Player/Camera ---
     pc_index: usize,
     player: client_core::controller::PlayerController,
@@ -363,6 +370,12 @@ pub struct Renderer {
     // NPC wizard casting rotation state
     wizard_fire_cycle_count: Vec<u32>,
     wizard_fireball_next_at: Vec<u32>,
+}
+
+pub struct VoxelChunkMesh {
+    pub vb: wgpu::Buffer,
+    pub ib: wgpu::Buffer,
+    pub idx: u32,
 }
 
 impl Renderer {

--- a/crates/render_wgpu/src/gfx/renderer/init.rs
+++ b/crates/render_wgpu/src/gfx/renderer/init.rs
@@ -959,9 +959,25 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
 
     // Prepare neutral gray voxel model BG (before moving device into struct)
     let voxel_model_bg = {
-        let mdl = crate::gfx::types::Model { model: glam::Mat4::IDENTITY.to_cols_array_2d(), color: [0.6,0.6,0.6], emissive: 0.02, _pad:[0.0;4] };
-        let buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor{ label: Some("voxel-model"), contents: bytemuck::bytes_of(&mdl), usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST });
-        device.create_bind_group(&wgpu::BindGroupDescriptor{ label: Some("voxel-model-bg"), layout: &model_bgl, entries: &[wgpu::BindGroupEntry{ binding:0, resource: buf.as_entire_binding() }] })
+        let mdl = crate::gfx::types::Model {
+            model: glam::Mat4::IDENTITY.to_cols_array_2d(),
+            color: [0.6, 0.6, 0.6],
+            emissive: 0.02,
+            _pad: [0.0; 4],
+        };
+        let buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("voxel-model"),
+            contents: bytemuck::bytes_of(&mdl),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("voxel-model-bg"),
+            layout: &model_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: buf.as_entire_binding(),
+            }],
+        })
     };
 
     Ok(crate::gfx::Renderer {

--- a/crates/render_wgpu/src/gfx/renderer/init.rs
+++ b/crates/render_wgpu/src/gfx/renderer/init.rs
@@ -957,6 +957,13 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
         (1.0, 2.0)
     };
 
+    // Prepare neutral gray voxel model BG (before moving device into struct)
+    let voxel_model_bg = {
+        let mdl = crate::gfx::types::Model { model: glam::Mat4::IDENTITY.to_cols_array_2d(), color: [0.6,0.6,0.6], emissive: 0.02, _pad:[0.0;4] };
+        let buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor{ label: Some("voxel-model"), contents: bytemuck::bytes_of(&mdl), usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST });
+        device.create_bind_group(&wgpu::BindGroupDescriptor{ label: Some("voxel-model-bg"), layout: &model_bgl, entries: &[wgpu::BindGroupEntry{ binding:0, resource: buf.as_entire_binding() }] })
+    };
+
     Ok(crate::gfx::Renderer {
         surface,
         device,
@@ -1111,6 +1118,8 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
         vox_last_chunks: 0,
         vox_queue_len: 0,
         vox_debris_last: 0,
+        voxel_meshes: std::collections::HashMap::new(),
+        voxel_model_bg,
         pc_index: scene_build.pc_index,
         player: client_core::controller::PlayerController::new(pc_initial_pos),
         scene_inputs: client_runtime::SceneInputs::new(pc_initial_pos),

--- a/crates/render_wgpu/src/gfx/renderer/render.rs
+++ b/crates/render_wgpu/src/gfx/renderer/render.rs
@@ -531,6 +531,29 @@ pub fn render_impl(r: &mut crate::gfx::Renderer) -> Result<(), SurfaceError> {
                 log::error!("validation after ruins: {:?}", e);
             }
         }
+        // Voxel chunk meshes (if any)
+        if !r.voxel_meshes.is_empty() {
+            let trace = std::env::var("RA_TRACE").map(|v| v == "1").unwrap_or(false);
+            if trace {
+                #[cfg(not(target_arch = "wasm32"))]
+                r.device.push_error_scope(wgpu::ErrorFilter::Validation);
+            }
+            rp.set_pipeline(&r.pipeline);
+            rp.set_bind_group(0, &r.globals_bg, &[]);
+            rp.set_bind_group(1, &r.voxel_model_bg, &[]);
+            for (_k, m) in &r.voxel_meshes {
+                rp.set_vertex_buffer(0, m.vb.slice(..));
+                rp.set_index_buffer(m.ib.slice(..), wgpu::IndexFormat::Uint32);
+                rp.draw_indexed(0..m.idx, 0, 0..1);
+                r.draw_calls += 1;
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            if trace {
+                if let Some(e) = pollster::block_on(r.device.pop_error_scope()) {
+                    log::error!("validation after voxel meshes: {:?}", e);
+                }
+            }
+        }
         // Skinned: wizards (use helper to ensure correct bind group order/index type)
         if std::env::var("RA_DRAW_WIZARDS")
             .map(|v| v != "0")

--- a/crates/render_wgpu/src/gfx/renderer/render.rs
+++ b/crates/render_wgpu/src/gfx/renderer/render.rs
@@ -541,17 +541,15 @@ pub fn render_impl(r: &mut crate::gfx::Renderer) -> Result<(), SurfaceError> {
             rp.set_pipeline(&r.pipeline);
             rp.set_bind_group(0, &r.globals_bg, &[]);
             rp.set_bind_group(1, &r.voxel_model_bg, &[]);
-            for (_k, m) in &r.voxel_meshes {
+            for m in r.voxel_meshes.values() {
                 rp.set_vertex_buffer(0, m.vb.slice(..));
                 rp.set_index_buffer(m.ib.slice(..), wgpu::IndexFormat::Uint32);
                 rp.draw_indexed(0..m.idx, 0, 0..1);
                 r.draw_calls += 1;
             }
             #[cfg(not(target_arch = "wasm32"))]
-            if trace {
-                if let Some(e) = pollster::block_on(r.device.pop_error_scope()) {
-                    log::error!("validation after voxel meshes: {:?}", e);
-                }
+            if trace && let Some(e) = pollster::block_on(r.device.pop_error_scope()) {
+                log::error!("validation after voxel meshes: {:?}", e);
             }
         }
         // Skinned: wizards (use helper to ensure correct bind group order/index type)

--- a/crates/render_wgpu/src/gfx/renderer/update.rs
+++ b/crates/render_wgpu/src/gfx/renderer/update.rs
@@ -637,8 +637,7 @@ impl Renderer {
         }
         let origin = DVec3::new(p0.x as f64, p0.y as f64, p0.z as f64);
         let dir_m = DVec3::new(dir.x as f64, dir.y as f64, dir.z as f64);
-        if let Some(hit) =
-            raycast_voxels(grid, origin, dir_m, self.destruct_cfg.voxel_size_m * 4.0)
+        if let Some(hit) = raycast_voxels(grid, origin, dir_m, self.destruct_cfg.voxel_size_m * 4.0)
         {
             // Carve a small hole at voxel center and schedule chunk updates
             let vm = grid.voxel_m().0;

--- a/crates/render_wgpu/src/gfx/renderer/update.rs
+++ b/crates/render_wgpu/src/gfx/renderer/update.rs
@@ -9,6 +9,7 @@ use glam::DVec3;
 use ra_assets::types::AnimClip;
 use rand::Rng as _;
 use server_core::destructible::{carve_and_spawn_debris, raycast_voxels};
+use wgpu::util::DeviceExt;
 
 impl Renderer {
     #[inline]
@@ -668,16 +669,42 @@ impl Renderer {
         let budget = self.destruct_cfg.max_chunk_remesh.max(1);
         let chunks = self.chunk_queue.pop_budget(budget);
         if let Some(grid) = self.voxel_grid.as_ref() {
-            // Refresh coarse colliders for these chunks
-            let mut updates: Vec<collision_static::chunks::StaticChunk> = Vec::new();
+            // Mesh changed chunks and upload to GPU; drop entries that became empty
             for c in &chunks {
-                if let Some(col) = chunkcol::build_chunk_collider(grid, *c) {
-                    updates.push(col);
+                let mb = voxel_mesh::greedy_mesh_chunk(grid, *c);
+                if mb.indices.is_empty() {
+                    self.voxel_meshes.remove(&(c.x, c.y, c.z));
+                } else {
+                    let vb = self
+                        .device
+                        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                            label: Some("voxel-chunk-vb"),
+                            contents: bytemuck::cast_slice(&mb.positions),
+                            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                        });
+                    let ib = self
+                        .device
+                        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                            label: Some("voxel-chunk-ib"),
+                            contents: bytemuck::cast_slice(&mb.indices),
+                            usage: wgpu::BufferUsages::INDEX | wgpu::BufferUsages::COPY_DST,
+                        });
+                    self.voxel_meshes
+                        .insert((c.x, c.y, c.z), crate::gfx::VoxelChunkMesh { vb, ib, idx: mb.indices.len() as u32 });
                 }
             }
-            if !updates.is_empty() {
-                chunkcol::swap_in_updates(&mut self.chunk_colliders, updates);
-                self.static_index = Some(chunkcol::rebuild_static_index(&self.chunk_colliders));
+            // Refresh coarse colliders for these chunks
+            if self.destruct_cfg.debris_vs_world {
+                let mut updates: Vec<collision_static::chunks::StaticChunk> = Vec::new();
+                for c in &chunks {
+                    if let Some(col) = chunkcol::build_chunk_collider(grid, *c) {
+                        updates.push(col);
+                    }
+                }
+                if !updates.is_empty() {
+                    chunkcol::swap_in_updates(&mut self.chunk_colliders, updates);
+                    self.static_index = Some(chunkcol::rebuild_static_index(&self.chunk_colliders));
+                }
             }
         }
         self.vox_last_chunks = chunks.len();

--- a/crates/voxel_mesh/src/lib.rs
+++ b/crates/voxel_mesh/src/lib.rs
@@ -231,7 +231,19 @@ fn greedy_emit(
                     }
                 }
                 // Emit quad at rectangle [x..x+w_run), [y..y+h_run)
-                emit_rect(mesh, axis, layer, x, y, w_run, h_run, vm, origin, normal);
+                emit_rect(
+                    mesh,
+                    axis,
+                    layer,
+                    x,
+                    y,
+                    w_run,
+                    h_run,
+                    vm,
+                    origin,
+                    normal,
+                    pos_normal,
+                );
                 x += w_run; // advance past rect
             } else {
                 x += 1;
@@ -253,6 +265,7 @@ fn emit_rect(
     vm: f32,
     origin: Vec3,
     normal: Vec3,
+    pos_normal: bool,
 ) {
     // Compute the 4 corners in voxel space at face plane
     let (ax_u, ax_v, ax_w) = match axis {
@@ -276,9 +289,14 @@ fn emit_rect(
     add(mesh, p1, normal);
     add(mesh, p2, normal);
     add(mesh, p3, normal);
-    // Two triangles (i0,i1,i2) and (i0,i2,i3)
-    mesh.indices
-        .extend_from_slice(&[i0, i0 + 1, i0 + 2, i0, i0 + 2, i0 + 3]);
+    // Two triangles; flip winding when normal is negative to keep faces front-facing
+    if pos_normal {
+        mesh.indices
+            .extend_from_slice(&[i0, i0 + 1, i0 + 2, i0, i0 + 2, i0 + 3]);
+    } else {
+        mesh.indices
+            .extend_from_slice(&[i0, i0 + 2, i0 + 1, i0, i0 + 3, i0 + 2]);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds slice-local per-chunk greedy meshing and draws voxel chunk meshes with the existing non-instanced pipeline, plus accurate impact placement and overlay counters.

Changes
- process_voxel_queues meshes changed chunks via `voxel_mesh::greedy_mesh_chunk`, uploads VB/IB, and stores per-chunk GPU buffers.
- Render pass loops through chunk meshes and draws them with a neutral material (new `voxel_model_bg`).
- Accurate impact = center of the hit voxel rather than projectile end.
- Overlay counters (`vox: queue/chunks/debris`) update on enqueue and process.

Notes
- CPU-only and off-by-default: path runs only when `voxel_grid` is `Some(..)`.
- Triplanar shading to be added next; current draw uses existing lit material color.
- Next PR will: create a demo voxel grid from `DestructibleConfig` (flags) and expand F3 overlay with timings.