### PR TITLE
demo: GLTF voxel world + debris cubes + F-to-blast + R-to-replay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ IMPORTANT: Keep `src/README.md` current
 - Branch name: `area/short-summary` (e.g., `gfx/fix-bottom-ghost`).
 - PR title: `area: imperative summary`.
 - Must include screenshots for UI, perf note if GPU cost changed ≥0.5 ms, and schema diffs if data changed.
+- Merge method: Always use squash-merge and delete the source branch after merge. When using the GitHub CLI:
+  - `gh pr merge <num> --squash --delete-branch` (use `--admin` if required).
 
 ## Build, Test, and Development Commands
 - Prerequisites: Install Rust via `rustup` (stable toolchain). If the edition is unsupported, run `rustup update`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4944,6 +4944,7 @@ dependencies = [
  "ux_hud",
  "voxel_mesh",
  "voxel_proxy",
+ "web-sys",
  "web-time",
  "wgpu 26.0.1",
  "winit",

--- a/crates/render_wgpu/Cargo.toml
+++ b/crates/render_wgpu/Cargo.toml
@@ -31,6 +31,7 @@ voxel_proxy = { version = "0.1.0", path = "../voxel_proxy" }
 voxel_mesh = { version = "0.1.0", path = "../voxel_mesh" }
 core_units = { version = "0.1.0", path = "../core_units" }
 core_materials = { version = "0.1.0", path = "../core_materials" }
+web-sys = { version = "0.3.70", features = ["Window", "Location"] }
 
 [dev-dependencies]
 sha2 = "0.10.9"

--- a/crates/render_wgpu/src/gfx/mod.rs
+++ b/crates/render_wgpu/src/gfx/mod.rs
@@ -332,6 +332,20 @@ pub struct Renderer {
     voxel_hashes: HashMap<(u32, u32, u32), u64>,
     // Simple model color for voxels (neutral gray)
     voxel_model_bg: wgpu::BindGroup,
+    // Debris (instanced cubes)
+    debris_vb: wgpu::Buffer,
+    debris_ib: wgpu::Buffer,
+    debris_index_count: u32,
+    debris_instances: wgpu::Buffer,
+    debris_capacity: u32,
+    debris_count: u32,
+    debris: Vec<Debris>,
+    debris_model_bg: wgpu::BindGroup,
+
+    // Demo helpers
+    voxel_grid_initial: Option<VoxelGrid>,
+    recent_impacts: Vec<(glam::DVec3, f64)>,
+    demo_hint_until: Option<f32>,
 
     // --- Player/Camera ---
     pc_index: usize,
@@ -383,6 +397,13 @@ pub struct VoxelChunkMesh {
     pub vb: wgpu::Buffer,
     pub ib: wgpu::Buffer,
     pub idx: u32,
+}
+
+struct Debris {
+    pos: glam::Vec3,
+    vel: glam::Vec3,
+    age: f32,
+    life: f32,
 }
 
 impl Renderer {

--- a/crates/render_wgpu/src/gfx/renderer/init.rs
+++ b/crates/render_wgpu/src/gfx/renderer/init.rs
@@ -961,7 +961,21 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
     };
 
     // Parse CLI flags for destructibles
-    let dcfg = DestructibleConfig::from_args(std::env::args());
+    #[allow(unused_mut)]
+    let mut dcfg = DestructibleConfig::from_args(std::env::args());
+    // On web, allow enabling demo via query param ?vox=1 (unless a model is specified)
+    #[cfg(target_arch = "wasm32")]
+    {
+        if dcfg.voxel_model.is_none() && !dcfg.demo_grid {
+            if let Some(win) = web_sys::window() {
+                if let Ok(href) = win.location().href() {
+                    if href.contains("vox=1") {
+                        dcfg.demo_grid = true;
+                    }
+                }
+            }
+        }
+    }
 
     // Prepare neutral gray voxel model BG (before moving device into struct)
     let voxel_model_bg = {

--- a/crates/render_wgpu/src/gfx/renderer/init.rs
+++ b/crates/render_wgpu/src/gfx/renderer/init.rs
@@ -967,7 +967,10 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
     let voxel_model_bg = {
         // Enable triplanar path for voxel meshes by setting _pad[0]=1, and
         // set tile frequency via _pad[1] derived from voxel size (meters).
-        let tiles_per_meter = (1.0f32 / (dcfg.voxel_size_m.0 as f32).max(1e-3)) * 0.25;
+        let mut tiles_per_meter = (1.0f32 / (dcfg.voxel_size_m.0 as f32).max(1e-3)) * 0.25;
+        if let Some(t) = dcfg.vox_tiles_per_meter {
+            tiles_per_meter = t.max(0.01);
+        }
         let mdl = crate::gfx::types::Model {
             model: glam::Mat4::IDENTITY.to_cols_array_2d(),
             color: [0.6, 0.6, 0.6],
@@ -989,8 +992,148 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
         })
     };
 
-    // Optionally create a demo voxel grid from flags (--voxel-demo)
-    let voxel_grid = if dcfg.demo_grid {
+    // Debris instancing: unit cube VB/IB and instance buffer
+    let (debris_vb, debris_ib, debris_index_count) = crate::gfx::mesh::create_cube(&device);
+    let debris_capacity = dcfg.max_debris as u32;
+    let debris_instances = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("debris-instances"),
+        size: (debris_capacity as usize * std::mem::size_of::<crate::gfx::types::Instance>())
+            as u64,
+        usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let debris_model_bg = {
+        let mdl = crate::gfx::types::Model {
+            model: glam::Mat4::IDENTITY.to_cols_array_2d(),
+            color: [0.55, 0.55, 0.55],
+            emissive: 0.0,
+            _pad: [0.0; 4],
+        };
+        let buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("debris-model"),
+            contents: bytemuck::bytes_of(&mdl),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("debris-model-bg"),
+            layout: &model_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: buf.as_entire_binding(),
+            }],
+        })
+    };
+
+    // Optionally create a voxel grid from a model (--voxel-model) or demo shell (--voxel-demo)
+    let voxel_grid = if let Some(ref model_path) = dcfg.voxel_model {
+        // Load triangles and voxelize a surface shell, then flood-fill
+        match ra_assets::gltf::load_gltf_mesh(std::path::Path::new(model_path)) {
+            Ok(cpu) => {
+                let mut min = glam::Vec3::splat(f32::INFINITY);
+                let mut max = glam::Vec3::splat(f32::NEG_INFINITY);
+                for v in &cpu.vertices {
+                    let p = glam::Vec3::from(v.pos);
+                    min = min.min(p);
+                    max = max.max(p);
+                }
+                if !min.is_finite() || !max.is_finite() {
+                    log::warn!("voxel-model: invalid bounds; falling back to demo grid");
+                    None
+                } else {
+                    let vm = dcfg.voxel_size_m.0 as f32;
+                    let origin = glam::DVec3::new(min.x as f64, min.y as f64, min.z as f64);
+                    let size = max - min;
+                    let dims = glam::UVec3::new(
+                        (size.x / vm).ceil().max(1.0) as u32 + 2,
+                        (size.y / vm).ceil().max(1.0) as u32 + 2,
+                        (size.z / vm).ceil().max(1.0) as u32 + 2,
+                    );
+                    let meta = VoxelProxyMeta {
+                        object_id: voxel_proxy::GlobalId(1),
+                        origin_m: origin,
+                        voxel_m: dcfg.voxel_size_m,
+                        dims,
+                        chunk: dcfg.chunk.min(dims.max(glam::UVec3::splat(1))),
+                        material: dcfg.material,
+                    };
+                    let mut surf = vec![0u8; (dims.x * dims.y * dims.z) as usize];
+                    let idx = |x: u32, y: u32, z: u32| -> usize {
+                        (x + y * dims.x + z * dims.x * dims.y) as usize
+                    };
+                    let verts = &cpu.vertices;
+                    let inds = &cpu.indices;
+                    for tri in inds.chunks_exact(3) {
+                        let a = glam::Vec3::from(verts[tri[0] as usize].pos);
+                        let b = glam::Vec3::from(verts[tri[1] as usize].pos);
+                        let c = glam::Vec3::from(verts[tri[2] as usize].pos);
+                        let n = (b - a).cross(c - a).normalize_or_zero();
+                        if !n.is_finite() || n.length_squared() < 1e-12 {
+                            continue;
+                        }
+                        let bbmin = a.min(b).min(c);
+                        let bbmax = a.max(b).max(c);
+                        let vmin = ((bbmin - min) / vm).floor().max(glam::Vec3::ZERO);
+                        let vmax = ((bbmax - min) / vm).ceil() + glam::Vec3::splat(1.0);
+                        let xi0 = vmin.x as u32;
+                        let yi0 = vmin.y as u32;
+                        let zi0 = vmin.z as u32;
+                        let xi1 = vmax.x.min(dims.x as f32) as u32;
+                        let yi1 = vmax.y.min(dims.y as f32) as u32;
+                        let zi1 = vmax.z.min(dims.z as f32) as u32;
+                        let thick = vm * 0.6;
+                        for z in zi0..zi1 {
+                            for y in yi0..yi1 {
+                                for x in xi0..xi1 {
+                                    let pc = glam::Vec3::new(
+                                        min.x + (x as f32 + 0.5) * vm,
+                                        min.y + (y as f32 + 0.5) * vm,
+                                        min.z + (z as f32 + 0.5) * vm,
+                                    );
+                                    let dist = (pc - a).dot(n);
+                                    if dist.abs() > thick {
+                                        continue;
+                                    }
+                                    let pproj = pc - dist * n;
+                                    let v0 = b - a;
+                                    let v1 = c - a;
+                                    let v2 = pproj - a;
+                                    let d00 = v0.dot(v0);
+                                    let d01 = v0.dot(v1);
+                                    let d11 = v1.dot(v1);
+                                    let d20 = v2.dot(v0);
+                                    let d21 = v2.dot(v1);
+                                    let denom = d00 * d11 - d01 * d01;
+                                    if denom.abs() < 1e-20 {
+                                        continue;
+                                    }
+                                    let v = (d11 * d20 - d01 * d21) / denom;
+                                    let w = (d00 * d21 - d01 * d20) / denom;
+                                    let u = 1.0 - v - w;
+                                    if u >= -0.05 && v >= -0.05 && w >= -0.05 {
+                                        surf[idx(x, y, z)] = 1;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    let mut grid = voxelize_surface_fill(meta.clone(), &surf, dcfg.close_surfaces);
+                    if grid.solid_count() == 0 && !dcfg.close_surfaces {
+                        log::warn!("voxel-model: empty after fill; retrying with close-surfaces");
+                        grid = voxelize_surface_fill(meta, &surf, true);
+                    }
+                    Some(grid)
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "voxel-model load failed ({}): {:?}. Falling back to demo",
+                    model_path,
+                    e
+                );
+                None
+            }
+        }
+    } else if dcfg.demo_grid {
         let chunk = dcfg.chunk;
         let dims = UVec3::new(chunk.x * 2, chunk.y, chunk.z * 2);
         let meta = VoxelProxyMeta {
@@ -1172,7 +1315,7 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
         hud_model: Default::default(),
         // Destructible defaults; leave grid None until provided by a loader/demo
         destruct_cfg: dcfg,
-        voxel_grid,
+        voxel_grid: voxel_grid.clone(),
         chunk_queue: server_core::destructible::queue::ChunkQueue::new(),
         chunk_colliders: Vec::new(),
         vox_last_chunks: 0,
@@ -1184,6 +1327,17 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
         voxel_meshes: std::collections::HashMap::new(),
         voxel_hashes: std::collections::HashMap::new(),
         voxel_model_bg,
+        debris_vb,
+        debris_ib,
+        debris_index_count,
+        debris_instances,
+        debris_capacity,
+        debris_count: 0,
+        debris: Vec::new(),
+        debris_model_bg,
+        voxel_grid_initial: voxel_grid,
+        recent_impacts: Vec::new(),
+        demo_hint_until: Some(5.0),
         impact_id: 0,
         pc_index: scene_build.pc_index,
         player: client_core::controller::PlayerController::new(pc_initial_pos),

--- a/crates/render_wgpu/src/gfx/renderer/input.rs
+++ b/crates/render_wgpu/src/gfx/renderer/input.rs
@@ -167,11 +167,33 @@ impl Renderer {
                             log::info!("Screenshot mode: 5s orbit starting");
                         }
                     }
+                    // Demo blast: press F to raycast and carve at first voxel hit
+                    PhysicalKey::Code(KeyCode::KeyF) => {
+                        if pressed {
+                            let m = if self.pc_index < self.wizard_models.len() {
+                                self.wizard_models[self.pc_index]
+                            } else {
+                                glam::Mat4::IDENTITY
+                            };
+                            let origin_w = (m * glam::Vec4::new(0.0, 1.2, 0.0, 1.0)).truncate();
+                            let dir_w = (m * glam::Vec4::new(0.0, 0.0, 1.0, 0.0))
+                                .truncate()
+                                .normalize_or_zero();
+                            let p0 = origin_w + dir_w * 0.5;
+                            let p1 = p0 + dir_w * 50.0;
+                            self.try_voxel_impact(p0, p1);
+                        }
+                    }
                     // Allow keyboard respawn as fallback when dead
                     PhysicalKey::Code(KeyCode::KeyR) | PhysicalKey::Code(KeyCode::Enter) => {
-                        if pressed && !self.pc_alive {
-                            log::info!("Respawn via keyboard");
-                            self.respawn();
+                        if pressed {
+                            if !self.pc_alive {
+                                log::info!("Respawn via keyboard");
+                                self.respawn();
+                            } else {
+                                // Reset destructible grid and replay recent impacts
+                                self.reset_voxel_and_replay();
+                            }
                         }
                     }
                     _ => {}


### PR DESCRIPTION
P0 playable destructibility demo, focused on visible, shippable functionality.

What’s in
- Asset voxelization (`--voxel-model <path>`): loads GLTF/GLB via `ra_assets::gltf::load_gltf_mesh`, rasterizes triangle shells into a surface map, and flood‑fills to a solid voxel grid. Falls back to `--voxel-demo` shell on failure; auto‑enables close‑surfaces if initial fill is empty.
- Debris you can see: instanced cube renderer (`debris_*`), simple gravity + ground bounces, lifetime timeout, capped by `--max-debris`.
- One input path: `F` fires a forward ray from the PC and calls `try_voxel_impact` (no spell preconditions). Carve radius guard clamps size to keep chunks touched under `--max-carve-chunks` (default 64), with a warning if clamped.
- Overlay improvements: `skipped=<N>` appears on the perf line (already merged), plus a short hint for first 5s: “Press F to blast (voxel destructible demo)”.
- Reset/replay (`R`): stores last three impacts; `R` resets the voxel grid, clears meshes/colliders, re‑enqueues all chunks, and replays the impacts deterministically.
- Tiles-per‑meter override: `--vox-tiles-per-meter` tweaks triplanar tiling; defaults remain derived from voxel size.
- Desktop convenience: if no destructible flags are provided, defaults to `--voxel-demo`.

Flags
- `--voxel-model <path>` — voxelize a GLTF/GLB and spawn as the destructible grid.
- `--vox-tiles-per-meter <f32>` — override triplanar scale.
- `--max-carve-chunks <u32>` — guardrail limit for sphere carve (default 64).
- Existing: `--voxel-demo`, `--voxel-size`, `--chunk-size`, `--mat`, `--max-debris`, `--max-chunk-remesh`, `--close-surfaces`, `--debris-vs-world`, `--seed`, `--replay-log`, `--replay`, `--help-vox`.

Acceptance
- `cargo run` shows the demo grid by default (desktop). `F` blasts a hole + visible debris; overlay updates, and `skipped` becomes non‑zero over repeated blasts. `R` resets + replays last 3 impacts identically. `--voxel-model assets/models/ruins.gltf` shows the voxelized ruin, carving & debris behave the same. Bad assets or leaky meshes don’t crash; we fall back or auto‑close surfaces with a warning.

Notes
- Triangle→voxel shell rasterizer is a simple plane‑thickness + barycentric‑inside pass (good enough for demo). Flood‑fill produces a solid proxy; close‑surfaces fallback covers small leaks.
- Debris uses existing instancing pipeline; color is neutral stone. World vs debris collisions remain guarded by the existing chunk‑collider flag (`--debris-vs-world`).
- CI: `cargo xtask ci` green (fmt, clippy ‑D warnings, WGSL validation, tests, schema).

Follow‑ups (optional, separate PR)
- Web param `?vox=1` to auto‑enable demo.
- `xtask demo` to build desktop+web bundles with assets.
- Rolling avg of remesh/collider ms on overlay.
