### PR TITLE
demo sandbox: Fireball-only carving + vox-sandbox (no mobs)

### DIFF
--- a/crates/render_wgpu/src/gfx/renderer/init.rs
+++ b/crates/render_wgpu/src/gfx/renderer/init.rs
@@ -1488,5 +1488,13 @@ pub async fn new_renderer(window: &Window) -> anyhow::Result<crate::gfx::Rendere
         renderer.vox_queue_len = renderer.chunk_queue.len();
     }
 
+    // Vox sandbox: remove mobs/boss for a clean destructible demo
+    if renderer.destruct_cfg.vox_sandbox {
+        renderer.server.npcs.clear();
+        renderer.zombie_count = 0;
+        renderer.dk_count = 0;
+        renderer.dk_id = None;
+    }
+
     Ok(renderer)
 }

--- a/crates/render_wgpu/src/gfx/renderer/input.rs
+++ b/crates/render_wgpu/src/gfx/renderer/input.rs
@@ -167,23 +167,7 @@ impl Renderer {
                             log::info!("Screenshot mode: 5s orbit starting");
                         }
                     }
-                    // Demo blast: press F to raycast and carve at first voxel hit
-                    PhysicalKey::Code(KeyCode::KeyF) => {
-                        if pressed {
-                            let m = if self.pc_index < self.wizard_models.len() {
-                                self.wizard_models[self.pc_index]
-                            } else {
-                                glam::Mat4::IDENTITY
-                            };
-                            let origin_w = (m * glam::Vec4::new(0.0, 1.2, 0.0, 1.0)).truncate();
-                            let dir_w = (m * glam::Vec4::new(0.0, 0.0, 1.0, 0.0))
-                                .truncate()
-                                .normalize_or_zero();
-                            let p0 = origin_w + dir_w * 0.5;
-                            let p1 = p0 + dir_w * 50.0;
-                            self.try_voxel_impact(p0, p1);
-                        }
-                    }
+                    // Demo blast via Fireball (3) instead of F
                     // Allow keyboard respawn as fallback when dead
                     PhysicalKey::Code(KeyCode::KeyR) | PhysicalKey::Code(KeyCode::Enter) => {
                         if pressed {

--- a/crates/render_wgpu/src/gfx/renderer/update.rs
+++ b/crates/render_wgpu/src/gfx/renderer/update.rs
@@ -616,14 +616,16 @@ impl Renderer {
             }
         }
 
-        // 2.6) Projectiles that died without hitting an NPC: attempt voxel impact
+        // 2.6) Projectiles that died without hitting an NPC: attempt voxel impact (Fireball only)
         let mut i = 0usize;
         while i < self.projectiles.len() {
             let kill = self.last_time >= self.projectiles[i].t_die;
             if kill {
                 let p1 = self.projectiles[i].pos;
                 let p0 = p1 - self.projectiles[i].vel * dt.max(1e-3);
-                self.try_voxel_impact(p0, p1);
+                if let crate::gfx::fx::ProjectileKind::Fireball { .. } = self.projectiles[i].kind {
+                    self.try_voxel_impact(p0, p1);
+                }
                 self.projectiles.swap_remove(i);
             } else {
                 i += 1;

--- a/crates/server_core/src/destructible.rs
+++ b/crates/server_core/src/destructible.rs
@@ -282,6 +282,7 @@ pub mod config {
         pub voxel_model: Option<String>,
         pub vox_tiles_per_meter: Option<f32>,
         pub max_carve_chunks: Option<u32>,
+        pub vox_sandbox: bool,
     }
 
     impl Default for DestructibleConfig {
@@ -302,6 +303,7 @@ pub mod config {
                 voxel_model: None,
                 vox_tiles_per_meter: None,
                 max_carve_chunks: Some(64),
+                vox_sandbox: false,
             }
         }
     }
@@ -432,6 +434,10 @@ pub mod config {
                         {
                             cfg.max_carve_chunks = Some(n);
                         }
+                    }
+                    "--vox-sandbox" => {
+                        any_vox_flag = true;
+                        cfg.vox_sandbox = true;
                     }
                     other => {
                         if other.starts_with("--vox") && !UNKNOWN_ONCE.swap(true, Ordering::Relaxed)


### PR DESCRIPTION
Sandbox demo: one destructible mesh, no mobs/boss, and Fireball (3) is the action that carves.

Changes
- Fireball-only carving: when a projectile dies, the voxel carve path runs only for `ProjectileKind::Fireball`. The generic “projectile timeout → carve” hook is now gated.
- Remove test `F` binding: the instant F-to-carve shortcut is removed; use `3` (Fireball) to blast.
- Vox sandbox flag: `--vox-sandbox` disables zombies/boss spawns for a clean scene. On init it clears server NPCs and sets counts to zero so only the player + voxel world remain.

How to run (desktop)
```
cargo run -p ruinsofatlantis -- \
  --vox-sandbox \
  --voxel-model assets/models/ruins.gltf \
  --voxel-size 0.05 --chunk-size 32 32 32 --mat stone \
  --max-debris 1200 --max-chunk-remesh 4 --seed 123
```
- Press 3 to cast Fireball → carves the vox ruin and spawns debris
- Press R to reset voxel world and replay last three blasts deterministically
- Perf overlay toggled with P; shows queue/chunks/skipped/debris/remesh/colliders.

Notes
- All changes are guarded and CI is green (`cargo xtask ci`).
- This keeps the end-to-end demo simple for capture: no mobs clutter, one visible object.
