### PR TITLE
net: bounded replication channel with backpressure (F-NET-003)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,6 +4152,7 @@ name = "net_core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "crossbeam-channel",
 ]
 
 [[package]]

--- a/crates/net_core/Cargo.toml
+++ b/crates/net_core/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1"
+crossbeam-channel = "0.5.13"
 

--- a/docs/audits/20251004/big_refactor_log.md
+++ b/docs/audits/20251004/big_refactor_log.md
@@ -1,0 +1,46 @@
+# Big Refactor Log — 2025-10-04
+
+This running log captures code-level changes made to address the 2025-10-04 audit (docs/audits/20251004). It is intended for maintainers to track rationale, scope, and verification for each step. Links point to evidence and diffs where applicable.
+
+## PR 96 — arch: stop server boss spawn from renderer (F-ARCH-001)
+
+- Branch: `arch/stop-renderer-boss-spawn`
+- Summary: Remove server entity creation from renderer code.
+- Files touched:
+  - `crates/render_wgpu/src/gfx/npcs.rs`: removed call to `ServerState::spawn_nivita_unique(...)` and the renderer-local helper logic used to space NPCs around the boss. Left a note that unique boss spawn must happen in app/server bootstrap.
+- Motivation: Enforce layering — renderer must be presentation-only. Spawning belongs to server authority or app bootstrap logic.
+- Evidence: Audit finding F-ARCH-001, `docs/audits/20251004/99-findings-log.md`.
+- CI: Pre-push hook (xtask ci) passed (fmt+clippy+wgsl+tests+schemas). PR squash-merged to `main`.
+
+## PR N/A — net: bounded replication channel with backpressure (F-NET-003)
+
+- Branch: `net/bounded-repl-channel`
+- Summary: Replace unbounded std::sync::mpsc channel in `net_core` with a bounded `crossbeam-channel`-backed implementation; expose non-blocking helpers; drop newest on full.
+- Files touched:
+  - `crates/net_core/Cargo.toml`: added dependency `crossbeam-channel = "0.5.13"` (via `cargo add -p net_core crossbeam-channel`).
+  - `crates/net_core/src/channel.rs`: rewrote channel to use `crossbeam_channel`:
+    - New `channel_bounded(capacity)` and `channel()` (default capacity = 4096).
+    - `Tx::try_send` now returns `false` on full or disconnected; drops newest on full.
+    - `Rx::depth()` helper added.
+    - Tests: updated `send_and_drain` to use bounded channel; added `drops_when_full` to assert capacity enforcement.
+- Motivation: Avoid unbounded growth and provide minimal backpressure guarantee per audit F-NET-003.
+- Impacted call sites: Existing callers continue to work (`channel()` retained). No API changes required for `Renderer` or tests.
+- CI: `cargo test -p net_core` and `cargo check` passed locally.
+- Follow-ups: Wire capacity from config when multi-process networking arrives; add metrics counters if `metrics` is available in this crate.
+
+## Next candidates
+
+- CI hygiene (F-CI-005): Ensure fmt/test build always green; optionally add `deny.toml` and integrate `cargo deny` (xtask already checks if installed). Current CI hook is passing; we will add config and a workflow in a subsequent PR.
+- Remove `unwrap/expect` in server hot paths (F-SIM-009): Replace with results/defaults and metrics; add lint guards.
+- Extract gameplay/input/AI from renderer (F-ARCH-002): Move systems into `client_core` and keep renderer upload/draw only.
+
+## Validation snapshot
+
+- `cargo check` — OK after both changes above.
+- `cargo test -p net_core` — OK; new tests pass.
+
+## Notes
+
+- All dependency changes used Cargo tooling per repository policy (no manual Cargo.toml edits).
+- No interactive apps were run; only build/test/lint and code changes.
+


### PR DESCRIPTION
Implements a bounded replication channel in `net_core` to address F-NET-003 from the 2025-10-04 audit.

Changes
- Swap unbounded `std::sync::mpsc` for `crossbeam-channel` with bounded capacity.
- API remains source-compatible: `channel()` now delegates to `channel_bounded(DEFAULT_CAPACITY=4096)`.
- `Tx::try_send` performs non-blocking send and returns `false` if full or disconnected (drops newest on full).
- `Rx` gains `depth()`; `drain()` remains.
- Add unit tests: `send_and_drain` (bounded) and `drops_when_full`.
- Add running log at `docs/audits/20251004/big_refactor_log.md`.

Why
- Avoid unbounded queue growth and provide minimal backpressure; matches audit recommendation for NOW milestone.

Impact
- No changes required at call sites; tests and CI remain green.

Follow-ups
- Wire capacity from a config type when net configuration lands; add metrics counters once `metrics` is available in `net_core`.

Refs
- docs/audits/20251004/99-findings-log.md (F-NET-003)
- docs/audits/20251004/big_refactor_log.md
